### PR TITLE
Option to disable shorten_names.

### DIFF
--- a/lib/ffi/gen.rb
+++ b/lib/ffi/gen.rb
@@ -86,6 +86,7 @@ class FFI::Gen
     end
     
     def shorten_names
+      return if @generator.no_shorten_names
       return if @constants.size < 2
       names = @constants.map { |constant| constant[:name].parts }
       names.each(&:shift) while names.map(&:first).uniq.size == 1 and @name.parts.map(&:downcase).include? names.first.first.downcase
@@ -259,17 +260,18 @@ class FFI::Gen
     end
   end
   
-  attr_reader :module_name, :ffi_lib, :headers, :prefixes, :output, :cflags
+  attr_reader :module_name, :ffi_lib, :headers, :prefixes, :output, :cflags, :no_shorten_names
 
   def initialize(options = {})
-    @module_name   = options[:module_name] or fail "No module name given."
-    @ffi_lib       = options[:ffi_lib] or fail "No FFI library given."
-    @headers       = options[:headers] or fail "No headers given."
-    @cflags        = options.fetch :cflags, []
-    @prefixes      = options.fetch :prefixes, []
-    @blocking      = options.fetch :blocking, []
-    @ffi_lib_flags = options.fetch :ffi_lib_flags, nil
-    @output        = options.fetch :output, $stdout
+    @module_name      = options[:module_name] or fail "No module name given."
+    @ffi_lib          = options[:ffi_lib] or fail "No FFI library given."
+    @headers          = options[:headers] or fail "No headers given."
+    @cflags           = options.fetch :cflags, []
+    @prefixes         = options.fetch :prefixes, []
+    @blocking         = options.fetch :blocking, []
+    @ffi_lib_flags    = options.fetch :ffi_lib_flags, nil
+    @output           = options.fetch :output, $stdout
+    @no_shorten_names = options.fetch :no_shorten_names, nil
     
     @translation_unit = nil
     @declarations = nil


### PR DESCRIPTION
Short name may cause confusion.
