### PR TITLE
Allow several names for the libclang lib

### DIFF
--- a/lib/ffi_gen/clang.rb
+++ b/lib/ffi_gen/clang.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module FFIGen::Clang
   extend FFI::Library
-  ffi_lib 'clang'
+  ffi_lib ['clang', 'clang-3.6', 'clang-3.5', 'clang-3.4', 'clang-3.3']
   
   # A single translation unit, which resides in an index.
   class TranslationUnitImpl < FFI::Struct


### PR DESCRIPTION
This fixes #20, allowing `rake test` to run.

Tests are still failing on my machine due to several different problems, mainly missing headers and libraries.