### PR TITLE
Various updates

### DIFF
--- a/ffi_gen.gemspec
+++ b/ffi_gen.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.author = "Richard Musiol"
   s.email = "mail@richard-musiol.de"
   s.homepage = "https://github.com/neelance/ffi_gen"
+  s.license = "MIT"
 
   s.add_dependency "ffi", "~> 1.0"
   s.files = Dir["lib/**/*.rb"] + ["LICENSE", "README.md", "lib/ffi_gen/empty.h"]

--- a/ffi_gen.gemspec
+++ b/ffi_gen.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email = "mail@richard-musiol.de"
   s.homepage = "https://github.com/neelance/ffi_gen"
 
-  s.add_dependency "ffi", ">= 1.0.0"
+  s.add_dependency "ffi", "~> 1.0"
   s.files = Dir["lib/**/*.rb"] + ["LICENSE", "README.md", "lib/ffi_gen/empty.h"]
   s.require_path = "lib"
 end

--- a/lib/ffi_gen.rb
+++ b/lib/ffi_gen.rb
@@ -689,6 +689,8 @@ class FFIGen
       ArrayType.new resolve_type(Clang.get_array_element_type(canonical_type)), Clang.get_array_size(canonical_type)
     when :unexposed, :function_proto
       UnknownType.new
+    when :incomplete_array
+      PointerType.new resolve_type(Clang.get_array_element_type(canonical_type)).name, 1
     else
       raise NotImplementedError, "No translation for values of type #{canonical_type[:kind]}"
     end

--- a/lib/ffi_gen.rb
+++ b/lib/ffi_gen.rb
@@ -12,7 +12,7 @@ class FFIGen
       }, nil
       children
     end
-    
+
     def get_spelling_location_data(location)
       file_ptr = FFI::MemoryPointer.new :pointer
       line_ptr = FFI::MemoryPointer.new :uint
@@ -31,60 +31,60 @@ class FFIGen
       (num_tokens - 1).times.map { |i| Clang::Token.new tokens_ptr[i] }
     end
   end
-  
+
   class Clang::String
     def to_s
       Clang.get_c_string self
     end
-    
+
     def to_s_and_dispose
       str = to_s
       Clang.dispose_string self
       str
     end
   end
-  
+
   class Clang::Cursor
     def ==(other)
       other.is_a?(Clang::Cursor) && Clang.equal_cursors(self, other) == 1
     end
-    
+
     def eql?(other)
       self == other
     end
-    
+
     def hash
       Clang.hash_cursor self
     end
   end
-  
+
   class Clang::Type
     def ==(other)
       other.is_a?(Clang::Type) && Clang.equal_types(self, other) == 1
     end
-    
+
     def eql?(other)
       self == other
     end
-    
+
     def hash
       0 # no hash available
     end
   end
-  
+
   class Type
   end
-  
+
   class Enum < Type
     attr_accessor :name
-    
+
     def initialize(generator, name, constants, description)
       @generator = generator
       @name = name
       @constants = constants
       @description = description
     end
-    
+
     def shorten_names
       return if @constants.size < 2
       names = @constants.map { |constant| constant[:name].parts }
@@ -92,11 +92,11 @@ class FFIGen
       names.each(&:pop) while names.map(&:last).uniq.size == 1 and @name.parts.map(&:downcase).include? names.first.last.downcase
     end
   end
-  
+
   class StructOrUnion < Type
     attr_accessor :name, :description
     attr_reader :fields, :oo_functions, :written
-    
+
     def initialize(generator, name, is_union)
       @generator = generator
       @name = name
@@ -107,10 +107,10 @@ class FFIGen
       @written = false
     end
   end
-  
+
   class FunctionOrCallback < Type
     attr_reader :name, :parameters, :return_type, :function_description, :return_value_description
-    
+
     def initialize(generator, name, parameters, return_type, is_callback, blocking, function_description, return_value_description)
       @generator = generator
       @name = name
@@ -122,7 +122,7 @@ class FFIGen
       @return_value_description = return_value_description
     end
   end
-  
+
   class Define
     def initialize(generator, name, parameters, value)
       @generator = generator
@@ -131,10 +131,10 @@ class FFIGen
       @value = value
     end
   end
-  
+
   class Writer
     attr_reader :output
-    
+
     def initialize(indentation_prefix, comment_prefix, comment_start = nil, comment_end = nil)
       @indentation_prefix = indentation_prefix
       @comment_prefix = comment_prefix
@@ -143,33 +143,33 @@ class FFIGen
       @current_indentation = ""
       @output = ""
     end
-    
+
     def indent(prefix = @indentation_prefix)
       previous_indentation = @current_indentation
       @current_indentation += prefix
       yield
       @current_indentation = previous_indentation
     end
-    
+
     def comment(&block)
       self.puts @comment_start unless @comment_start.nil?
       self.indent @comment_prefix, &block
       self.puts @comment_end unless @comment_end.nil?
     end
-    
+
     def puts(*lines)
       lines.each do |line|
         @output << "#{@current_indentation}#{line}\n"
       end
     end
-    
+
     def write_array(array, separator = "", first_line_prefix = "", other_lines_prefix = "")
       array.each_with_index do |entry, index|
         entry = yield entry if block_given?
         puts "#{index == 0 ? first_line_prefix : other_lines_prefix}#{entry}#{index < array.size - 1 ? separator : ''}"
       end
     end
-    
+
     def write_description(description, not_documented_message = true, first_line_prefix = "", other_lines_prefix = "")
       description.shift while not description.empty? and description.first.strip.empty?
       description.pop while not description.empty? and description.last.strip.empty?
@@ -177,19 +177,19 @@ class FFIGen
       space_prefix_length = description.map{ |line| line.index(/\S/) }.compact.min
       description.map! { |line| line[space_prefix_length..-1] }
       description << (not_documented_message ? "(Not documented)" : "") if description.empty?
-      
+
       write_array description, "", first_line_prefix, other_lines_prefix
     end
   end
-  
+
   class Name
     attr_reader :parts, :raw
-    
+
     def initialize(parts, raw = nil)
       @parts = parts
       @raw = raw
     end
-    
+
     def format(*modes, keyword_blacklist)
       parts = @parts.dup
       parts.map!(&:downcase) if modes.include? :downcase
@@ -202,63 +202,63 @@ class FFIGen
       str
     end
   end
-  
+
   class PrimitiveType < Type
     def initialize(clang_type)
       @clang_type = clang_type
     end
-    
+
     def name
       Name.new [@clang_type.to_s]
     end
   end
-  
+
   class StringType < Type
     def name
       Name.new ["string"]
     end
   end
-  
+
   class ByValueType < Type
     def initialize(inner_type)
       @inner_type = inner_type
     end
-    
+
     def name
       @inner_type.name
     end
   end
-  
+
   class PointerType < Type
     attr_reader :pointee_name, :depth
-    
+
     def initialize(pointee_name, depth)
       @pointee_name = pointee_name
       @depth = depth
     end
-    
+
     def name
       @pointee_name
     end
   end
-  
+
   class ArrayType < Type
     def initialize(element_type, constant_size)
       @element_type = element_type
       @constant_size = constant_size
     end
-    
+
     def name
       Name.new ["array"]
     end
   end
-    
+
   class UnknownType < Type
     def name
       Name.new ["unknown"]
     end
   end
-  
+
   attr_reader :module_name, :ffi_lib, :headers, :prefixes, :output, :cflags
 
   def initialize(options = {})
@@ -271,11 +271,11 @@ class FFIGen
     @blocking      = options.fetch :blocking, []
     @ffi_lib_flags = options.fetch :ffi_lib_flags, nil
     @output        = options.fetch :output, $stdout
-    
+
     @translation_unit = nil
     @declarations = nil
   end
-  
+
   def generate
     code = send "generate_#{File.extname(@output)[1..-1]}"
     if @output.is_a? String
@@ -285,10 +285,10 @@ class FFIGen
       @output.write code
     end
   end
-  
+
   def translation_unit
     return @translation_unit unless @translation_unit.nil?
-    
+
     args = []
     @headers.each do |header|
       args.push "-include", header unless header.is_a? Regexp
@@ -297,32 +297,32 @@ class FFIGen
     args_ptr = FFI::MemoryPointer.new :pointer, args.size
     pointers = args.map { |arg| FFI::MemoryPointer.from_string arg }
     args_ptr.write_array_of_pointer pointers
-    
+
     index = Clang.create_index 0, 0
     @translation_unit = Clang.parse_translation_unit index, File.join(File.dirname(__FILE__), "ffi_gen/empty.h"), args_ptr, args.size, nil, 0, Clang.enum_type(:translation_unit_flags)[:detailed_preprocessing_record]
-    
+
     Clang.get_num_diagnostics(@translation_unit).times do |i|
       diag = Clang.get_diagnostic @translation_unit, i
       $stderr.puts Clang.format_diagnostic(diag, Clang.default_diagnostic_display_options).to_s_and_dispose
     end
-    
+
     @translation_unit
   end
-  
+
   def declarations
     return @declarations unless @declarations.nil?
-    
+
     header_files = []
     Clang.get_inclusions translation_unit, proc { |included_file, inclusion_stack, include_length, client_data|
       filename = Clang.get_file_name(included_file).to_s_and_dispose
       header_files << included_file if @headers.any? { |header| header.is_a?(Regexp) ? header =~ filename : filename.end_with?(header) }
     }, nil
-    
+
     unit_cursor = Clang.get_translation_unit_cursor translation_unit
     declaration_cursors = Clang.get_children unit_cursor
     declaration_cursors.delete_if { |cursor| [:macro_expansion, :inclusion_directive, :var_decl].include? cursor[:kind] }
     declaration_cursors.delete_if { |cursor| !header_files.include?(Clang.get_spelling_location_data(Clang.get_cursor_location(cursor))[:file]) }
-    
+
     is_nested_declaration = []
     min_offset = Clang.get_spelling_location_data(Clang.get_cursor_location(declaration_cursors.last))[:offset]
     declaration_cursors.reverse_each do |declaration_cursor|
@@ -330,7 +330,7 @@ class FFIGen
       is_nested_declaration.unshift(offset > min_offset)
       min_offset = offset if offset < min_offset
     end
-    
+
     @declarations = []
     @declarations_by_name = {}
     @declarations_by_type = {}
@@ -342,16 +342,16 @@ class FFIGen
         comment, _ = extract_comment translation_unit, comment_range
         previous_declaration_end = Clang.get_range_end Clang.get_cursor_extent(declaration_cursor)
       end
-      
+
       read_declaration declaration_cursor, comment
     end
 
     @declarations
   end
-  
+
   def read_declaration(declaration_cursor, comment)
     name = read_name declaration_cursor
-    
+
     declaration = case declaration_cursor[:kind]
     when :enum_decl
       enum_description = []
@@ -365,19 +365,19 @@ class FFIGen
         current_description = enum_description if line.strip.empty?
         current_description << line
       end
-      
+
       constants = []
       previous_constant_location = Clang.get_cursor_location declaration_cursor
       next_constant_value = 0
       Clang.get_children(declaration_cursor).each do |enum_constant|
         constant_name = read_name enum_constant
-        
+
         constant_location = Clang.get_cursor_location enum_constant
         constant_comment_range = Clang.get_range previous_constant_location, constant_location
         constant_description, _ = extract_comment translation_unit, constant_comment_range
         constant_description.concat(constant_descriptions[constant_name.raw] || [])
         previous_constant_location = constant_location
-        
+
         begin
           value_cursor = Clang.get_children(enum_constant).first
           constant_value = if value_cursor
@@ -402,7 +402,7 @@ class FFIGen
           else
             next_constant_value
           end
-          
+
           constants << { name: constant_name, value: constant_value, comment: constant_description }
           next_constant_value = constant_value + 1
         rescue ArgumentError
@@ -411,12 +411,12 @@ class FFIGen
       end
 
       Enum.new self, name, constants, enum_description
-      
+
     when :struct_decl, :union_decl
       struct = @declarations_by_type[Clang.get_cursor_type(declaration_cursor)] || StructOrUnion.new(self, name, (declaration_cursor[:kind] == :union_decl))
       raise if not struct.fields.empty?
       struct.description.concat comment
-      
+
       struct_children = Clang.get_children declaration_cursor
       previous_field_end = Clang.get_cursor_location declaration_cursor
       last_nested_declaration = nil
@@ -428,10 +428,10 @@ class FFIGen
         when :field_decl
           field_name = read_name child
           field_extent = Clang.get_cursor_extent child
-          
+
           field_comment_range = Clang.get_range previous_field_end, Clang.get_range_start(field_extent)
           field_comment, _ = extract_comment translation_unit, field_comment_range
-          
+
           # check for comment starting on same line
           next_field_start = struct_children.first ? Clang.get_cursor_location(struct_children.first) : Clang.get_range_end(Clang.get_cursor_extent(declaration_cursor))
           following_comment_range = Clang.get_range Clang.get_range_end(field_extent), next_field_start
@@ -442,7 +442,7 @@ class FFIGen
           else
             previous_field_end = Clang.get_range_end field_extent
           end
-          
+
           field_type = resolve_type Clang.get_cursor_type(child)
           last_nested_declaration.name ||= Name.new(name.parts + field_name.parts) if last_nested_declaration
           last_nested_declaration = nil
@@ -451,9 +451,9 @@ class FFIGen
           raise
         end
       end
-      
+
       struct
-    
+
     when :function_decl
       function_description = []
       return_value_description = []
@@ -467,7 +467,7 @@ class FFIGen
         current_description = return_value_description if line.gsub! '\\returns ', ''
         current_description << line
       end
-      
+
       return_type = resolve_type Clang.get_cursor_result_type(declaration_cursor)
       parameters = []
       first_parameter_type = nil
@@ -482,15 +482,15 @@ class FFIGen
         first_parameter_type ||= Clang.get_cursor_type function_child
         parameters << { name: param_name, type: param_type }
       end
-      
+
       parameters.each_with_index do |parameter, index|
         parameter[:description] = parameter[:name] && parameter_descriptions[parameter[:name].raw]
         parameter[:description] ||= parameter_descriptions.values[index] if parameter_descriptions.size == parameters.size # workaround for wrong names
         parameter[:description] ||= []
       end
-      
+
       function = FunctionOrCallback.new self, name, parameters, return_type, false, @blocking.include?(name.raw), function_description, return_value_description
-      
+
       pointee_declaration = first_parameter_type && get_pointee_declaration(first_parameter_type)
       if pointee_declaration
         type_prefix = pointee_declaration.name.parts.join.downcase
@@ -503,9 +503,9 @@ class FFIGen
           pointee_declaration.oo_functions << [Name.new(function_name_parts), function]
         end
       end
-      
+
       function
-    
+
     when :typedef_decl
       typedef_children = Clang.get_children declaration_cursor
       if typedef_children.size == 1
@@ -525,7 +525,7 @@ class FFIGen
       else
         nil
       end
-        
+
     when :macro_definition
       tokens = Clang.get_tokens(translation_unit, Clang.get_cursor_extent(declaration_cursor)).map { |token|
         [Clang.get_token_kind(token), Clang.get_token_spelling(translation_unit, token).to_s_and_dispose]
@@ -617,22 +617,22 @@ class FFIGen
       else
         nil
       end
-    
+
     else
       raise declaration_cursor[:kind].to_s
 
     end
-    
+
     return nil if declaration.nil?
     @declarations.delete declaration
     @declarations << declaration
     @declarations_by_name[name] = name.raw unless name.nil?
     type = Clang.get_cursor_type declaration_cursor
     @declarations_by_type[type] = declaration unless type.nil?
-    
+
     declaration
   end
-  
+
   def resolve_type(full_type, is_array = false)
     canonical_type = Clang.get_canonical_type full_type
     data_array = case canonical_type[:kind]
@@ -653,7 +653,7 @@ class FFIGen
         else
           nil
         end
-        
+
         if type.nil?
           pointer_depth = 0
           pointee_name = ""
@@ -662,7 +662,7 @@ class FFIGen
             declaration_cursor = Clang.get_type_declaration current_type
             pointee_name = read_name declaration_cursor
             break if pointee_name
-  
+
             case current_type[:kind]
             when :pointer
               pointer_depth += 1
@@ -676,7 +676,7 @@ class FFIGen
           end
           type = PointerType.new pointee_name, pointer_depth
         end
-        
+
         type
       end
     when :record
@@ -693,7 +693,7 @@ class FFIGen
       raise NotImplementedError, "No translation for values of type #{canonical_type[:kind]}"
     end
   end
-  
+
   def read_name(source)
     source = Clang.get_cursor_spelling(source).to_s_and_dispose if source.is_a? Clang::Cursor
     return nil if source.empty?
@@ -702,7 +702,7 @@ class FFIGen
     parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?)
     Name.new parts, source
   end
-  
+
   def get_pointee_declaration(type)
     canonical_type = Clang.get_canonical_type type
     return nil if canonical_type[:kind] != :pointer
@@ -710,10 +710,10 @@ class FFIGen
     return nil if pointee_type[:kind] != :record
     @declarations_by_type[Clang.get_cursor_type(Clang.get_type_declaration(pointee_type))]
   end
-  
+
   def extract_comment(translation_unit, range, search_backwards = true)
     tokens = Clang.get_tokens translation_unit, range
-    
+
     iterator = search_backwards ? tokens.reverse_each : tokens.each
     comment_lines = []
     comment_token = nil
@@ -737,7 +737,7 @@ class FFIGen
 
     return comment_lines, comment_token
   end
-  
+
   def self.generate(options = {})
     self.new(options).generate
   end

--- a/lib/ffi_gen.rb
+++ b/lib/ffi_gen.rb
@@ -749,8 +749,8 @@ end
 if __FILE__ == $0
   FFIGen.generate(
     module_name: "FFIGen::Clang",
-    ffi_lib:     "clang",
-    headers:     ["clang-c/Index.h"],
+    ffi_lib:     ["libclang-3.5.so.1", "libclang.so.1", "clang"],
+    headers:     ["clang-c/CXErrorCode.h", "clang-c/CXString.h", "clang-c/Index.h"],
     cflags:      `llvm-config --cflags`.split(" "),
     prefixes:    ["clang_", "CX"],
     output:      File.join(File.dirname(__FILE__), "ffi_gen/clang.rb")

--- a/lib/ffi_gen/clang.rb
+++ b/lib/ffi_gen/clang.rb
@@ -4,7 +4,80 @@ require 'ffi'
 
 module FFIGen::Clang
   extend FFI::Library
-  ffi_lib 'clang'
+  ffi_lib ["libclang-3.5.so.1", "libclang.so.1", "clang"]
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
+  CINDEX_VERSION_MAJOR = 0
+  
+  CINDEX_VERSION_MINOR = 27
+  
+  def cindex_version_stringize(major, minor)
+    cindex_version_stringize(major, minor)
+  end
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:error_code).</em>
+  # 
+  # === Options:
+  # :success ::
+  #   No error.
+  # :failure ::
+  #   A generic error code, no further details are available.
+  #   
+  #   Errors of this kind can get their own specific error codes in future
+  #   libclang versions.
+  # :crashed ::
+  #   libclang crashed while performing the requested operation.
+  # :invalid_arguments ::
+  #   The function detected that the arguments violate the function
+  #   contract.
+  # :ast_read_error ::
+  #   An AST deserialization error has occurred.
+  # 
+  # @method _enum_error_code_
+  # @return [Symbol]
+  # @scope class
+  enum :error_code, [
+    :success, 0,
+    :failure, 1,
+    :crashed, 2,
+    :invalid_arguments, 3,
+    :ast_read_error, 4
+  ]
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :data ::
+  #   (FFI::Pointer(*Void)) 
+  # :private_flags ::
+  #   (Integer) 
+  class String < FFI::Struct
+    layout :data, :pointer,
+           :private_flags, :uint
+  end
+  
+  # Retrieve the character data associated with the given string.
+  # 
+  # @method get_c_string(string)
+  # @param [String] string 
+  # @return [String] 
+  # @scope class
+  attach_function :get_c_string, :clang_getCString, [String.by_value], :string
+  
+  # Free the given string.
+  # 
+  # @method dispose_string(string)
+  # @param [String] string 
+  # @return [nil] 
+  # @scope class
+  attach_function :dispose_string, :clang_disposeString, [String.by_value], :void
   
   # A single translation unit, which resides in an index.
   class TranslationUnitImpl < FFI::Struct
@@ -54,47 +127,35 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :availability_kind, [
-    :available,
-    :deprecated,
-    :not_available,
-    :not_accessible
+    :available, 0,
+    :deprecated, 1,
+    :not_available, 2,
+    :not_accessible, 3
   ]
   
-  # A character string.
-  # 
-  # The \c CXString type is used to return strings from the interface when
-  # the ownership of that string might different from one call to the next.
-  # Use \c clang_getCString() to retrieve the string data and, once finished
-  # with the string data, call \c clang_disposeString() to free the string.
+  # Describes a version number of the form major.minor.subminor.
   # 
   # = Fields:
-  # :data ::
-  #   (FFI::Pointer(*Void)) 
-  # :private_flags ::
-  #   (Integer) 
-  class String < FFI::Struct
-    layout :data, :pointer,
-           :private_flags, :uint
+  # :major ::
+  #   (Integer) The major version number, e.g., the '10' in '10.7.3'. A negative
+  #   value indicates that there is no version number at all.
+  # :minor ::
+  #   (Integer) The minor version number, e.g., the '7' in '10.7.3'. This value
+  #   will be negative if no minor version number was provided, e.g., for 
+  #   version '10'.
+  # :subminor ::
+  #   (Integer) The subminor version number, e.g., the '3' in '10.7.3'. This value
+  #   will be negative if no minor or subminor version number was provided,
+  #   e.g., in version '10' or '10.7'.
+  class Version < FFI::Struct
+    layout :major, :int,
+           :minor, :int,
+           :subminor, :int
   end
   
-  # Retrieve the character data associated with the given string.
+  # Provides a shared context for creating translation units.
   # 
-  # @method get_c_string(string)
-  # @param [String] string 
-  # @return [String] 
-  # @scope class
-  attach_function :get_c_string, :clang_getCString, [String.by_value], :string
-  
-  # Free the given string,
-  # 
-  # @method dispose_string(string)
-  # @param [String] string 
-  # @return [nil] 
-  # @scope class
-  attach_function :dispose_string, :clang_disposeString, [String.by_value], :void
-  
-  # clang_createIndex() provides a shared context for creating
-  # translation units. It provides two options:
+  # It provides two options:
   # 
   # - excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
   # declarations (when loading any new translation units). A "local" declaration
@@ -104,6 +165,7 @@ module FFIGen::Clang
   # 
   # Here is an example:
   # 
+  # \code
   #   // excludeDeclsFromPCH = 1, displayDiagnostics=1
   #   Idx = clang_createIndex(1, 1);
   # 
@@ -124,6 +186,7 @@ module FFIGen::Clang
   #   clang_visitChildren(clang_getTranslationUnitCursor(TU),
   #                       TranslationUnitVisitor, 0);
   #   clang_disposeTranslationUnit(TU);
+  # \endcode
   # 
   # This process of creating the 'pch', loading it separately, and using it (via
   # -include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
@@ -147,6 +210,61 @@ module FFIGen::Clang
   # @scope class
   attach_function :dispose_index, :clang_disposeIndex, [:pointer], :void
   
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:global_opt_flags).</em>
+  # 
+  # === Options:
+  # :none ::
+  #   Used to indicate that no special CXIndex options are needed.
+  # :thread_background_priority_for_indexing ::
+  #   Used to indicate that threads that libclang creates for indexing
+  #   purposes should use background priority.
+  #   
+  #   Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
+  #   #clang_parseTranslationUnit, #clang_saveTranslationUnit.
+  # :thread_background_priority_for_editing ::
+  #   Used to indicate that threads that libclang creates for editing
+  #   purposes should use background priority.
+  #   
+  #   Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
+  #   #clang_annotateTokens
+  # 
+  # @method _enum_global_opt_flags_
+  # @return [Symbol]
+  # @scope class
+  enum :global_opt_flags, [
+    :none, 0,
+    :thread_background_priority_for_indexing, 1,
+    :thread_background_priority_for_editing, 2
+  ]
+  
+  # Sets general options associated with a CXIndex.
+  # 
+  # For example:
+  # \code
+  # CXIndex idx = ...;
+  # clang_CXIndex_setGlobalOptions(idx,
+  #     clang_CXIndex_getGlobalOptions(idx) |
+  #     CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+  # \endcode
+  # 
+  # @method cx_index_set_global_options(index, options)
+  # @param [FFI::Pointer(Index)] index 
+  # @param [Integer] options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
+  # @return [nil] 
+  # @scope class
+  attach_function :cx_index_set_global_options, :clang_CXIndex_setGlobalOptions, [:pointer, :uint], :void
+  
+  # Gets the general options associated with a CXIndex.
+  # 
+  # @method cx_index_get_global_options(index)
+  # @param [FFI::Pointer(Index)] index 
+  # @return [Integer] A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
+  #   are associated with the given CXIndex object.
+  # @scope class
+  attach_function :cx_index_get_global_options, :clang_CXIndex_getGlobalOptions, [:pointer], :uint
+  
   # Retrieve the complete file and path name of the given file.
   # 
   # @method get_file_name(s_file)
@@ -163,9 +281,29 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_file_time, :clang_getFileTime, [:pointer], :long
   
+  # Uniquely identifies a CXFile, that refers to the same underlying file,
+  # across an indexing session.
+  # 
+  # = Fields:
+  # :data ::
+  #   (Array<Integer>) 
+  class FileUniqueID < FFI::Struct
+    layout :data, [:ulong_long, 3]
+  end
+  
+  # Retrieve the unique ID for the given \c file.
+  # 
+  # @method get_file_unique_id(file, out_id)
+  # @param [FFI::Pointer(File)] file the file to get the ID for.
+  # @param [FileUniqueID] out_id stores the returned CXFileUniqueID.
+  # @return [Integer] If there was a failure getting the unique ID, returns non-zero,
+  #   otherwise returns 0.
+  # @scope class
+  attach_function :get_file_unique_id, :clang_getFileUniqueID, [:pointer, FileUniqueID], :int
+  
   # Determine whether the given header is guarded against
   # multiple inclusions, either with the conventional
-  # #ifndef/#define/#endif macro guards or with #pragma once.
+  # \#ifndef/\#define/\#endif macro guards or with \#pragma once.
   # 
   # @method is_file_multiple_include_guarded(tu, file)
   # @param [TranslationUnitImpl] tu 
@@ -260,6 +398,23 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_location_for_offset, :clang_getLocationForOffset, [TranslationUnitImpl, :pointer, :uint], SourceLocation.by_value
   
+  # Returns non-zero if the given source location is in a system header.
+  # 
+  # @method location_is_in_system_header(location)
+  # @param [SourceLocation] location 
+  # @return [Integer] 
+  # @scope class
+  attach_function :location_is_in_system_header, :clang_Location_isInSystemHeader, [SourceLocation.by_value], :int
+  
+  # Returns non-zero if the given source location is in the main file of
+  # the corresponding translation unit.
+  # 
+  # @method location_is_from_main_file(location)
+  # @param [SourceLocation] location 
+  # @return [Integer] 
+  # @scope class
+  attach_function :location_is_from_main_file, :clang_Location_isFromMainFile, [SourceLocation.by_value], :int
+  
   # Retrieve a NULL (invalid) source range.
   # 
   # @method get_null_range()
@@ -270,9 +425,9 @@ module FFIGen::Clang
   # Retrieve a source range given the beginning and ending source
   # locations.
   # 
-  # @method get_range(begin, end)
-  # @param [SourceLocation] begin 
-  # @param [SourceLocation] end 
+  # @method get_range(begin_, end_)
+  # @param [SourceLocation] begin_ 
+  # @param [SourceLocation] end_ 
   # @return [SourceRange] 
   # @scope class
   attach_function :get_range, :clang_getRange, [SourceLocation.by_value, SourceLocation.by_value], SourceRange.by_value
@@ -286,7 +441,7 @@ module FFIGen::Clang
   # @scope class
   attach_function :equal_ranges, :clang_equalRanges, [SourceRange.by_value, SourceRange.by_value], :uint
   
-  # Returns non-zero if \arg range is null.
+  # Returns non-zero if \p range is null.
   # 
   # @method range_is_null(range)
   # @param [SourceRange] range 
@@ -295,16 +450,39 @@ module FFIGen::Clang
   attach_function :range_is_null, :clang_Range_isNull, [SourceRange.by_value], :int
   
   # Retrieve the file, line, column, and offset represented by
+  # the given source location.
+  # 
+  # If the location refers into a macro expansion, retrieves the
+  # location of the macro expansion.
+  # 
+  # @method get_expansion_location(location, file, line, column, offset)
+  # @param [SourceLocation] location the location within a source file that will be decomposed
+  #   into its parts.
+  # @param [FFI::Pointer(*File)] file (out) if non-NULL, will be set to the file to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] line (out) if non-NULL, will be set to the line to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] column (out) if non-NULL, will be set to the column to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] offset (out) if non-NULL, will be set to the offset into the
+  #   buffer to which the given source location points.
+  # @return [nil] 
+  # @scope class
+  attach_function :get_expansion_location, :clang_getExpansionLocation, [SourceLocation.by_value, :pointer, :pointer, :pointer, :pointer], :void
+  
+  # Retrieve the file, line, column, and offset represented by
   # the given source location, as specified in a # line directive.
   # 
   # Example: given the following source code in a file somefile.c
   # 
+  # \code
   # #123 "dummy.c" 1
   # 
   # static int func(void)
   # {
   #     return 0;
   # }
+  # \endcode
   # 
   # the location information returned by this function would be
   # 
@@ -336,7 +514,7 @@ module FFIGen::Clang
   # by the given source location.
   # 
   # This interface has been replaced by the newer interface
-  # \see clang_getExpansionLocation(). See that interface's documentation for
+  # #clang_getExpansionLocation(). See that interface's documentation for
   # details.
   # 
   # @method get_instantiation_location(location, file, line, column, offset)
@@ -370,6 +548,28 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_spelling_location, :clang_getSpellingLocation, [SourceLocation.by_value, :pointer, :pointer, :pointer, :pointer], :void
   
+  # Retrieve the file, line, column, and offset represented by
+  # the given source location.
+  # 
+  # If the location refers into a macro expansion, return where the macro was
+  # expanded or where the macro argument was written, if the location points at
+  # a macro argument.
+  # 
+  # @method get_file_location(location, file, line, column, offset)
+  # @param [SourceLocation] location the location within a source file that will be decomposed
+  #   into its parts.
+  # @param [FFI::Pointer(*File)] file (out) if non-NULL, will be set to the file to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] line (out) if non-NULL, will be set to the line to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] column (out) if non-NULL, will be set to the column to which the given
+  #   source location points.
+  # @param [FFI::Pointer(*UInt)] offset (out) if non-NULL, will be set to the offset into the
+  #   buffer to which the given source location points.
+  # @return [nil] 
+  # @scope class
+  attach_function :get_file_location, :clang_getFileLocation, [SourceLocation.by_value, :pointer, :pointer, :pointer, :pointer], :void
+  
   # Retrieve a source location representing the first character within a
   # source range.
   # 
@@ -387,6 +587,38 @@ module FFIGen::Clang
   # @return [SourceLocation] 
   # @scope class
   attach_function :get_range_end, :clang_getRangeEnd, [SourceRange.by_value], SourceLocation.by_value
+  
+  # Identifies an array of ranges.
+  # 
+  # = Fields:
+  # :count ::
+  #   (Integer) The number of ranges in the \c ranges array.
+  # :ranges ::
+  #   (SourceRange) An array of \c CXSourceRanges.
+  class SourceRangeList < FFI::Struct
+    layout :count, :uint,
+           :ranges, SourceRange
+  end
+  
+  # Retrieve all ranges that were skipped by the preprocessor.
+  # 
+  # The preprocessor will skip lines when they are surrounded by an
+  # if/ifdef/ifndef directive whose condition does not evaluate to true.
+  # 
+  # @method get_skipped_ranges(tu, file)
+  # @param [TranslationUnitImpl] tu 
+  # @param [FFI::Pointer(File)] file 
+  # @return [SourceRangeList] 
+  # @scope class
+  attach_function :get_skipped_ranges, :clang_getSkippedRanges, [TranslationUnitImpl, :pointer], SourceRangeList
+  
+  # Destroy the given \c CXSourceRangeList.
+  # 
+  # @method dispose_source_range_list(ranges)
+  # @param [SourceRangeList] ranges 
+  # @return [nil] 
+  # @scope class
+  attach_function :dispose_source_range_list, :clang_disposeSourceRangeList, [SourceRangeList], :void
   
   # Describes the severity of a particular diagnostic.
   # 
@@ -420,6 +652,85 @@ module FFIGen::Clang
     :fatal, 4
   ]
   
+  # Determine the number of diagnostics in a CXDiagnosticSet.
+  # 
+  # @method get_num_diagnostics_in_set(diags)
+  # @param [FFI::Pointer(DiagnosticSet)] diags 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_num_diagnostics_in_set, :clang_getNumDiagnosticsInSet, [:pointer], :uint
+  
+  # Retrieve a diagnostic associated with the given CXDiagnosticSet.
+  # 
+  # @method get_diagnostic_in_set(diags, index)
+  # @param [FFI::Pointer(DiagnosticSet)] diags the CXDiagnosticSet to query.
+  # @param [Integer] index the zero-based diagnostic number to retrieve.
+  # @return [FFI::Pointer(Diagnostic)] the requested diagnostic. This diagnostic must be freed
+  #   via a call to \c clang_disposeDiagnostic().
+  # @scope class
+  attach_function :get_diagnostic_in_set, :clang_getDiagnosticInSet, [:pointer, :uint], :pointer
+  
+  # Describes the kind of error that occurred (if any) in a call to
+  # \c clang_loadDiagnostics.
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:load_diag_error).</em>
+  # 
+  # === Options:
+  # :none ::
+  #   Indicates that no error occurred.
+  # :unknown ::
+  #   Indicates that an unknown error occurred while attempting to
+  #   deserialize diagnostics.
+  # :cannot_load ::
+  #   Indicates that the file containing the serialized diagnostics
+  #   could not be opened.
+  # :invalid_file ::
+  #   Indicates that the serialized diagnostics file is invalid or
+  #   corrupt.
+  # 
+  # @method _enum_load_diag_error_
+  # @return [Symbol]
+  # @scope class
+  enum :load_diag_error, [
+    :none, 0,
+    :unknown, 1,
+    :cannot_load, 2,
+    :invalid_file, 3
+  ]
+  
+  # Deserialize a set of diagnostics from a Clang diagnostics bitcode
+  # file.
+  # 
+  # @method load_diagnostics(file, error, error_string)
+  # @param [String] file The name of the file to deserialize.
+  # @param [FFI::Pointer(*LoadDiagError)] error A pointer to a enum value recording if there was a problem
+  #          deserializing the diagnostics.
+  # @param [String] error_string A pointer to a CXString for recording the error string
+  #          if the file was not successfully loaded.
+  # @return [FFI::Pointer(DiagnosticSet)] A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
+  #   diagnostics should be released using clang_disposeDiagnosticSet().
+  # @scope class
+  attach_function :load_diagnostics, :clang_loadDiagnostics, [:string, :pointer, String], :pointer
+  
+  # Release a CXDiagnosticSet and all of its contained diagnostics.
+  # 
+  # @method dispose_diagnostic_set(diags)
+  # @param [FFI::Pointer(DiagnosticSet)] diags 
+  # @return [nil] 
+  # @scope class
+  attach_function :dispose_diagnostic_set, :clang_disposeDiagnosticSet, [:pointer], :void
+  
+  # Retrieve the child diagnostics of a CXDiagnostic. 
+  # 
+  # This CXDiagnosticSet does not need to be released by
+  # clang_disposeDiagnosticSet.
+  # 
+  # @method get_child_diagnostics(d)
+  # @param [FFI::Pointer(Diagnostic)] d 
+  # @return [FFI::Pointer(DiagnosticSet)] 
+  # @scope class
+  attach_function :get_child_diagnostics, :clang_getChildDiagnostics, [:pointer], :pointer
+  
   # Determine the number of diagnostics produced for the given
   # translation unit.
   # 
@@ -439,6 +750,15 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_diagnostic, :clang_getDiagnostic, [TranslationUnitImpl, :uint], :pointer
   
+  # Retrieve the complete set of diagnostics associated with a
+  #        translation unit.
+  # 
+  # @method get_diagnostic_set_from_tu(unit)
+  # @param [TranslationUnitImpl] unit the translation unit to query.
+  # @return [FFI::Pointer(DiagnosticSet)] 
+  # @scope class
+  attach_function :get_diagnostic_set_from_tu, :clang_getDiagnosticSetFromTU, [TranslationUnitImpl], :pointer
+  
   # Destroy a diagnostic.
   # 
   # @method dispose_diagnostic(diagnostic)
@@ -450,12 +770,12 @@ module FFIGen::Clang
   # Options to control the display of diagnostics.
   # 
   # The values in this enum are meant to be combined to customize the
-  # behavior of \c clang_displayDiagnostic().
+  # behavior of \c clang_formatDiagnostic().
   # 
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:diagnostic_display_options).</em>
   # 
   # === Options:
-  # :display_source_location ::
+  # :source_location ::
   #   Display the source-location information where the
   #   diagnostic was located.
   #   
@@ -467,31 +787,31 @@ module FFIGen::Clang
   #   \endcode
   #   
   #   This option corresponds to the clang flag \c -fshow-source-location.
-  # :display_column ::
+  # :column ::
   #   If displaying the source-location information of the
   #   diagnostic, also include the column number.
   #   
   #   This option corresponds to the clang flag \c -fshow-column.
-  # :display_source_ranges ::
+  # :source_ranges ::
   #   If displaying the source-location information of the
   #   diagnostic, also include information about source ranges in a
   #   machine-parsable format.
   #   
   #   This option corresponds to the clang flag
   #   \c -fdiagnostics-print-source-range-info.
-  # :display_option ::
+  # :option ::
   #   Display the option name associated with this diagnostic, if any.
   #   
   #   The option name displayed (e.g., -Wconversion) will be placed in brackets
   #   after the diagnostic text. This option corresponds to the clang flag
   #   \c -fdiagnostics-show-option.
-  # :display_category_id ::
+  # :category_id ::
   #   Display the category number associated with this diagnostic, if any.
   #   
   #   The category number is displayed within brackets after the diagnostic text.
   #   This option corresponds to the clang flag 
   #   \c -fdiagnostics-show-category=id.
-  # :display_category_name ::
+  # :category_name ::
   #   Display the category name associated with this diagnostic, if any.
   #   
   #   The category name is displayed within brackets after the diagnostic text.
@@ -502,12 +822,12 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :diagnostic_display_options, [
-    :display_source_location, 0x01,
-    :display_column, 0x02,
-    :display_source_ranges, 0x04,
-    :display_option, 0x08,
-    :display_category_id, 0x10,
-    :display_category_name, 0x20
+    :source_location, 1,
+    :column, 2,
+    :source_ranges, 4,
+    :option, 8,
+    :category_id, 16,
+    :category_name, 32
   ]
   
   # Format the given diagnostic in a manner that is suitable for display.
@@ -530,7 +850,7 @@ module FFIGen::Clang
   # 
   # @method default_diagnostic_display_options()
   # @return [Integer] A set of display options suitable for use with \c
-  #   clang_displayDiagnostic().
+  #   clang_formatDiagnostic().
   # @scope class
   attach_function :default_diagnostic_display_options, :clang_defaultDiagnosticDisplayOptions, [], :uint
   
@@ -586,7 +906,9 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_diagnostic_category, :clang_getDiagnosticCategory, [:pointer], :uint
   
-  # Retrieve the name of a particular diagnostic category.
+  # Retrieve the name of a particular diagnostic category.  This
+  #  is now deprecated.  Use clang_getDiagnosticCategoryText()
+  #  instead.
   # 
   # @method get_diagnostic_category_name(category)
   # @param [Integer] category A diagnostic category number, as returned by 
@@ -594,6 +916,14 @@ module FFIGen::Clang
   # @return [String] The name of the given diagnostic category.
   # @scope class
   attach_function :get_diagnostic_category_name, :clang_getDiagnosticCategoryName, [:uint], String.by_value
+  
+  # Retrieve the diagnostic category text for a given diagnostic.
+  # 
+  # @method get_diagnostic_category_text(diagnostic)
+  # @param [FFI::Pointer(Diagnostic)] diagnostic 
+  # @return [String] The text of the given diagnostic category.
+  # @scope class
+  attach_function :get_diagnostic_category_text, :clang_getDiagnosticCategoryText, [:pointer], String.by_value
   
   # Determine the number of source ranges associated with the given
   # diagnostic.
@@ -671,20 +1001,20 @@ module FFIGen::Clang
   #   '-c'
   #   '-emit-ast'
   #   '-fsyntax-only'
-  #   '-o <output file>'  (both '-o' and '<output file>' are ignored)
+  #   '-o \<output file>'  (both '-o' and '\<output file>' are ignored)
   # 
   # @method create_translation_unit_from_source_file(c_idx, source_filename, num_clang_command_line_args, command_line_args, num_unsaved_files, unsaved_files)
   # @param [FFI::Pointer(Index)] c_idx The index object with which the translation unit will be
   #   associated.
-  # @param [String] source_filename - The name of the source file to load, or NULL if the
+  # @param [String] source_filename The name of the source file to load, or NULL if the
   #   source file is included in \p clang_command_line_args.
   # @param [Integer] num_clang_command_line_args The number of command-line arguments in
   #   \p clang_command_line_args.
-  # @param [FFI::Pointer(**Char_S)] command_line_args The command-line arguments that would be
+  # @param [FFI::Pointer(**CharS)] command_line_args The command-line arguments that would be
   #   passed to the \c clang executable if it were being invoked out-of-process.
   #   These command-line options will be parsed and will affect how the translation
   #   unit is parsed. Note that the following options are ignored: '-c',
-  #   '-emit-ast', '-fsyntex-only' (which is the default), and '-o <output file>'.
+  #   '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
   # @param [Integer] num_unsaved_files the number of unsaved file entries in \p
   #   unsaved_files.
   # @param [UnsavedFile] unsaved_files the files that have not yet been saved to disk
@@ -696,14 +1026,30 @@ module FFIGen::Clang
   # @scope class
   attach_function :create_translation_unit_from_source_file, :clang_createTranslationUnitFromSourceFile, [:pointer, :string, :int, :pointer, :uint, UnsavedFile], TranslationUnitImpl
   
-  # Create a translation unit from an AST file (-emit-ast).
+  # Same as \c clang_createTranslationUnit2, but returns
+  # the \c CXTranslationUnit instead of an error code.  In case of an error this
+  # routine returns a \c NULL \c CXTranslationUnit, without further detailed
+  # error codes.
   # 
-  # @method create_translation_unit(index, ast_filename)
-  # @param [FFI::Pointer(Index)] index 
+  # @method create_translation_unit(c_idx, ast_filename)
+  # @param [FFI::Pointer(Index)] c_idx 
   # @param [String] ast_filename 
   # @return [TranslationUnitImpl] 
   # @scope class
   attach_function :create_translation_unit, :clang_createTranslationUnit, [:pointer, :string], TranslationUnitImpl
+  
+  # Create a translation unit from an AST file (\c -emit-ast).
+  # 
+  # \param(out) out_TU A non-NULL pointer to store the created
+  # \c CXTranslationUnit.
+  # 
+  # @method create_translation_unit2(c_idx, ast_filename, out_tu)
+  # @param [FFI::Pointer(Index)] c_idx 
+  # @param [String] ast_filename 
+  # @param [FFI::Pointer(*TranslationUnit)] out_tu 
+  # @return [Symbol from _enum_error_code_] Zero on success, otherwise returns an error code.
+  # @scope class
+  attach_function :create_translation_unit2, :clang_createTranslationUnit2, [:pointer, :string, :pointer], :error_code
   
   # Flags that control the creation of translation units.
   # 
@@ -756,37 +1102,41 @@ module FFIGen::Clang
   #   Caching of code-completion results is a performance optimization that
   #   introduces some overhead to reparsing but improves the performance of
   #   code-completion operations.
-  # :x_precompiled_preamble ::
-  #   DEPRECATED: Enable precompiled preambles in C++.
+  # :for_serialization ::
+  #   Used to indicate that the translation unit will be serialized with
+  #   \c clang_saveTranslationUnit.
   #   
-  #   Note: this is a *temporary* option that is available only while
-  #   we are testing C++ precompiled preamble support. It is deprecated.
-  # :x_chained_pch ::
+  #   This option is typically used when parsing a header with the intent of
+  #   producing a precompiled header.
+  # :cxx_chained_pch ::
   #   DEPRECATED: Enabled chained precompiled preambles in C++.
   #   
   #   Note: this is a *temporary* option that is available only while
   #   we are testing C++ precompiled preamble support. It is deprecated.
-  # :nested_macro_expansions ::
-  #   Used to indicate that the "detailed" preprocessing record,
-  #   if requested, should also contain nested macro expansions.
+  # :skip_function_bodies ::
+  #   Used to indicate that function/method bodies should be skipped while
+  #   parsing.
   #   
-  #   Nested macro expansions (i.e., macro expansions that occur
-  #   inside another macro expansion) can, in some code bases, require
-  #   a large amount of storage to due preprocessor metaprogramming. Moreover,
-  #   its fairly rare that this information is useful for libclang clients.
+  #   This option can be used to search for declarations/definitions while
+  #   ignoring the usages.
+  # :include_brief_comments_in_code_completion ::
+  #   Used to indicate that brief documentation comments should be
+  #   included into the set of code completions returned from this translation
+  #   unit.
   # 
   # @method _enum_translation_unit_flags_
   # @return [Symbol]
   # @scope class
   enum :translation_unit_flags, [
-    :none, 0x0,
-    :detailed_preprocessing_record, 0x01,
-    :incomplete, 0x02,
-    :precompiled_preamble, 0x04,
-    :cache_completion_results, 0x08,
-    :x_precompiled_preamble, 0x10,
-    :x_chained_pch, 0x20,
-    :nested_macro_expansions, 0x40
+    :none, 0,
+    :detailed_preprocessing_record, 1,
+    :incomplete, 2,
+    :precompiled_preamble, 4,
+    :cache_completion_results, 8,
+    :for_serialization, 16,
+    :cxx_chained_pch, 32,
+    :skip_function_bodies, 64,
+    :include_brief_comments_in_code_completion, 128
   ]
   
   # Returns the set of flags that is suitable for parsing a translation
@@ -805,6 +1155,23 @@ module FFIGen::Clang
   # @scope class
   attach_function :default_editing_translation_unit_options, :clang_defaultEditingTranslationUnitOptions, [], :uint
   
+  # Same as \c clang_parseTranslationUnit2, but returns
+  # the \c CXTranslationUnit instead of an error code.  In case of an error this
+  # routine returns a \c NULL \c CXTranslationUnit, without further detailed
+  # error codes.
+  # 
+  # @method parse_translation_unit(c_idx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options)
+  # @param [FFI::Pointer(Index)] c_idx 
+  # @param [String] source_filename 
+  # @param [FFI::Pointer(**CharS)] command_line_args 
+  # @param [Integer] num_command_line_args 
+  # @param [UnsavedFile] unsaved_files 
+  # @param [Integer] num_unsaved_files 
+  # @param [Integer] options 
+  # @return [TranslationUnitImpl] 
+  # @scope class
+  attach_function :parse_translation_unit, :clang_parseTranslationUnit, [:pointer, :string, :pointer, :int, UnsavedFile, :uint, :uint], TranslationUnitImpl
+  
   # Parse the given source file and the translation unit corresponding
   # to that file.
   # 
@@ -814,18 +1181,18 @@ module FFIGen::Clang
   # command-line arguments so that the compilation can be configured in the same
   # way that the compiler is configured on the command line.
   # 
-  # @method parse_translation_unit(c_idx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options)
+  # @method parse_translation_unit2(c_idx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options, out_tu)
   # @param [FFI::Pointer(Index)] c_idx The index object with which the translation unit will be 
   #   associated.
   # @param [String] source_filename The name of the source file to load, or NULL if the
-  #   source file is included in \p command_line_args.
-  # @param [FFI::Pointer(**Char_S)] command_line_args The command-line arguments that would be
+  #   source file is included in \c command_line_args.
+  # @param [FFI::Pointer(**CharS)] command_line_args The command-line arguments that would be
   #   passed to the \c clang executable if it were being invoked out-of-process.
   #   These command-line options will be parsed and will affect how the translation
   #   unit is parsed. Note that the following options are ignored: '-c', 
-  #   '-emit-ast', '-fsyntex-only' (which is the default), and '-o <output file>'.
+  #   '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
   # @param [Integer] num_command_line_args The number of command-line arguments in
-  #   \p command_line_args.
+  #   \c command_line_args.
   # @param [UnsavedFile] unsaved_files the files that have not yet been saved to disk
   #   but may be required for parsing, including the contents of
   #   those files.  The contents and name of these files (as specified by
@@ -836,11 +1203,14 @@ module FFIGen::Clang
   # @param [Integer] options A bitmask of options that affects how the translation unit
   #   is managed but not its compilation. This should be a bitwise OR of the
   #   CXTranslationUnit_XXX flags.
-  # @return [TranslationUnitImpl] A new translation unit describing the parsed code and containing
-  #   any diagnostics produced by the compiler. If there is a failure from which
-  #   the compiler cannot recover, returns NULL.
+  #   
+  #   \param(out) out_TU A non-NULL pointer to store the created
+  #   \c CXTranslationUnit, describing the parsed code and containing any
+  #   diagnostics produced by the compiler.
+  # @param [FFI::Pointer(*TranslationUnit)] out_tu 
+  # @return [Symbol from _enum_error_code_] Zero on success, otherwise returns an error code.
   # @scope class
-  attach_function :parse_translation_unit, :clang_parseTranslationUnit, [:pointer, :string, :pointer, :int, UnsavedFile, :uint, :uint], TranslationUnitImpl
+  attach_function :parse_translation_unit2, :clang_parseTranslationUnit2, [:pointer, :string, :pointer, :int, UnsavedFile, :uint, :uint, :pointer], :error_code
   
   # Flags that control how translation units are saved.
   # 
@@ -858,7 +1228,7 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :save_translation_unit_flags, [
-    :save_translation_unit_none, 0x0
+    :save_translation_unit_none, 0
   ]
   
   # Returns the set of flags that is suitable for saving a translation
@@ -955,7 +1325,7 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :reparse_flags, [
-    :reparse_none, 0x0
+    :reparse_none, 0
   ]
   
   # Returns the set of flags that is suitable for reparsing a translation
@@ -1002,10 +1372,11 @@ module FFIGen::Clang
   # @param [Integer] options A bitset of options composed of the flags in CXReparse_Flags.
   #   The function \c clang_defaultReparseOptions() produces a default set of
   #   options recommended for most uses, based on the translation unit.
-  # @return [Integer] 0 if the sources could be reparsed. A non-zero value will be
+  # @return [Integer] 0 if the sources could be reparsed.  A non-zero error code will be
   #   returned if reparsing was impossible, such that the translation unit is
-  #   invalid. In such cases, the only valid call for \p TU is 
-  #   \c clang_disposeTranslationUnit(TU).
+  #   invalid. In such cases, the only valid call for \c TU is
+  #   \c clang_disposeTranslationUnit(TU).  The error codes returned by this
+  #   routine are described by the \c CXErrorCode enum.
   # @scope class
   attach_function :reparse_translation_unit, :clang_reparseTranslationUnit, [TranslationUnitImpl, :uint, UnsavedFile, :uint], :int
   
@@ -1151,13 +1522,13 @@ module FFIGen::Clang
   # :parm_decl ::
   #   A function or method parameter.
   # :obj_c_interface_decl ::
-  #   An Objective-C @interface.
+  #   An Objective-C \@interface.
   # :obj_c_category_decl ::
-  #   An Objective-C @interface for a category.
+  #   An Objective-C \@interface for a category.
   # :obj_c_protocol_decl ::
-  #   An Objective-C @protocol declaration.
+  #   An Objective-C \@protocol declaration.
   # :obj_c_property_decl ::
-  #   An Objective-C @property declaration.
+  #   An Objective-C \@property declaration.
   # :obj_c_ivar_decl ::
   #   An Objective-C instance variable.
   # :obj_c_instance_method_decl ::
@@ -1165,12 +1536,12 @@ module FFIGen::Clang
   # :obj_c_class_method_decl ::
   #   An Objective-C class method.
   # :obj_c_implementation_decl ::
-  #   An Objective-C @implementation.
+  #   An Objective-C \@implementation.
   # :obj_c_category_impl_decl ::
-  #   An Objective-C @implementation for a category.
+  #   An Objective-C \@implementation for a category.
   # :typedef_decl ::
   #   A typedef
-  # :x_method ::
+  # :cxx_method ::
   #   A C++ class method.
   # :namespace ::
   #   A C++ namespace.
@@ -1203,10 +1574,10 @@ module FFIGen::Clang
   # :type_alias_decl ::
   #   A C++ alias declaration
   # :obj_c_synthesize_decl ::
-  #   An Objective-C @synthesize definition.
+  #   An Objective-C \@synthesize definition.
   # :obj_c_dynamic_decl ::
-  #   An Objective-C @dynamic definition.
-  # :x_access_specifier ::
+  #   An Objective-C \@dynamic definition.
+  # :cxx_access_specifier ::
   #   An access specifier.
   # :first_ref ::
   #   References
@@ -1230,7 +1601,7 @@ module FFIGen::Clang
   #   The typedef is a declaration of size_type (CXCursor_TypedefDecl),
   #   while the type of the variable "size" is referenced. The cursor
   #   referenced by the type of size is the typedef for size_type.
-  # :x_base_specifier ::
+  # :cxx_base_specifier ::
   #   
   # :template_ref ::
   #   A reference to a class template, function template, template
@@ -1289,6 +1660,9 @@ module FFIGen::Clang
   #   The functions \c clang_getNumOverloadedDecls() and 
   #   \c clang_getOverloadedDecl() can be used to retrieve the definitions
   #   referenced by this cursor.
+  # :variable_ref ::
+  #   A reference to a variable that occurs in some non-expression 
+  #   context, e.g., a C++ lambda capture list.
   # :first_invalid ::
   #   Error conditions
   # :invalid_file ::
@@ -1311,7 +1685,7 @@ module FFIGen::Clang
   #   expression is not reported.
   # :decl_ref_expr ::
   #   An expression that refers to some value declaration, such
-  #   as a function, varible, or enumerator.
+  #   as a function, variable, or enumerator.
   # :member_ref_expr ::
   #   An expression that refers to a member of a struct, union,
   #   class, Objective-C class, etc.
@@ -1362,7 +1736,7 @@ module FFIGen::Clang
   # :stmt_expr ::
   #   This is the GNU Statement Expression extension: ({int X=4; X;})
   # :generic_selection_expr ::
-  #   Represents a C1X generic selection.
+  #   Represents a C11 generic selection.
   # :gnu_null_expr ::
   #   Implements the GNU __null extension, which is a name for a null
   #   pointer constant that has integral type (e.g., int or long) and is the same
@@ -1371,15 +1745,15 @@ module FFIGen::Clang
   #   The __null extension is typically only used by system headers, which define
   #   NULL as __null in C++ rather than using 0 (which is an integer that may not
   #   match the size of a pointer).
-  # :x_static_cast_expr ::
+  # :cxx_static_cast_expr ::
   #   C++'s static_cast<> expression.
-  # :x_dynamic_cast_expr ::
+  # :cxx_dynamic_cast_expr ::
   #   C++'s dynamic_cast<> expression.
-  # :x_reinterpret_cast_expr ::
+  # :cxx_reinterpret_cast_expr ::
   #   C++'s reinterpret_cast<> expression.
-  # :x_const_cast_expr ::
+  # :cxx_const_cast_expr ::
   #   C++'s const_cast<> expression.
-  # :x_functional_cast_expr ::
+  # :cxx_functional_cast_expr ::
   #   Represents an explicit C++ type conversion that uses "functional"
   #   notion (C++ (expr.type.conv)).
   #   
@@ -1387,35 +1761,35 @@ module FFIGen::Clang
   #   \code
   #     x = int(0.5);
   #   \endcode
-  # :x_typeid_expr ::
+  # :cxx_typeid_expr ::
   #   A C++ typeid expression (C++ (expr.typeid)).
-  # :x_bool_literal_expr ::
+  # :cxx_bool_literal_expr ::
   #   (C++ 2.13.5) C++ Boolean Literal.
-  # :x_null_ptr_literal_expr ::
+  # :cxx_null_ptr_literal_expr ::
   #   (C++0x 2.14.7) C++ Pointer Literal.
-  # :x_this_expr ::
+  # :cxx_this_expr ::
   #   Represents the "this" expression in C++
-  # :x_throw_expr ::
+  # :cxx_throw_expr ::
   #   (C++ 15) C++ Throw Expression.
   #   
   #   This handles 'throw' and 'throw' assignment-expression. When
   #   assignment-expression isn't present, Op will be null.
-  # :x_new_expr ::
+  # :cxx_new_expr ::
   #   A new expression for memory allocation and constructor calls, e.g:
   #   "new CXXNewExpr(foo)".
-  # :x_delete_expr ::
+  # :cxx_delete_expr ::
   #   A delete expression for memory deallocation and destructor calls,
   #   e.g. "delete() pArray".
   # :unary_expr ::
   #   A unary expression.
   # :obj_c_string_literal ::
-  #   ObjCStringLiteral, used for Objective-C string literals i.e. "foo".
+  #   An Objective-C string literal i.e. @"foo".
   # :obj_c_encode_expr ::
-  #   ObjCEncodeExpr, used for in Objective-C.
+  #   An Objective-C \@encode expression.
   # :obj_c_selector_expr ::
-  #   ObjCSelectorExpr used for in Objective-C.
+  #   An Objective-C \@selector expression.
   # :obj_c_protocol_expr ::
-  #   Objective-C's protocol expression.
+  #   An Objective-C \@protocol expression.
   # :obj_c_bridged_cast_expr ::
   #   An Objective-C "bridged" cast expression, which casts between
   #   Objective-C pointers and C pointers, transferring ownership in the process.
@@ -1446,6 +1820,22 @@ module FFIGen::Clang
   #     static const unsigned value = sizeof...(Types);
   #   };
   #   \endcode
+  # :lambda_expr ::
+  #   Represents a C++ lambda expression that produces a local function
+  #   object.
+  #   
+  #   \code
+  #   void abssort(float *x, unsigned N) {
+  #     std::sort(x, x + N,
+  #               ()(float a, float b) {
+  #                 return std::abs(a) < std::abs(b);
+  #               });
+  #   }
+  #   \endcode
+  # :obj_c_bool_literal_expr ::
+  #   Objective-c Boolean Literal.
+  # :obj_c_self_expr ::
+  #   Represents the "self" expression in an Objective-C method.
   # :first_stmt ::
   #   Statements
   # :unexposed_stmt ::
@@ -1472,7 +1862,7 @@ module FFIGen::Clang
   #   This cursor kind is used to describe compound statements, e.g. function
   #   bodies.
   # :case_stmt ::
-  #   A case statment.
+  #   A case statement.
   # :default_stmt ::
   #   A default statement.
   # :if_stmt ::
@@ -1495,27 +1885,27 @@ module FFIGen::Clang
   #   A break statement.
   # :return_stmt ::
   #   A return statement.
-  # :asm_stmt ::
-  #   A GNU inline assembly statement extension.
+  # :gcc_asm_stmt ::
+  #   A GCC inline assembly statement extension.
   # :obj_c_at_try_stmt ::
-  #   Objective-C's overall @try-@catc-@finall statement.
+  #   Objective-C's overall \@try-\@catch-\@finally statement.
   # :obj_c_at_catch_stmt ::
-  #   Objective-C's @catch statement.
+  #   Objective-C's \@catch statement.
   # :obj_c_at_finally_stmt ::
-  #   Objective-C's @finally statement.
+  #   Objective-C's \@finally statement.
   # :obj_c_at_throw_stmt ::
-  #   Objective-C's @throw statement.
+  #   Objective-C's \@throw statement.
   # :obj_c_at_synchronized_stmt ::
-  #   Objective-C's @synchronized statement.
+  #   Objective-C's \@synchronized statement.
   # :obj_c_autorelease_pool_stmt ::
   #   Objective-C's autorelease pool statement.
   # :obj_c_for_collection_stmt ::
   #   Objective-C's collection statement.
-  # :x_catch_stmt ::
+  # :cxx_catch_stmt ::
   #   C++'s catch statement.
-  # :x_try_stmt ::
+  # :cxx_try_stmt ::
   #   C++'s try statement.
-  # :x_for_range_stmt ::
+  # :cxx_for_range_stmt ::
   #   C++'s for (* : *) statement.
   # :seh_try_stmt ::
   #   Windows Structured Exception Handling's try statement.
@@ -1523,6 +1913,8 @@ module FFIGen::Clang
   #   Windows Structured Exception Handling's except statement.
   # :seh_finally_stmt ::
   #   Windows Structured Exception Handling's finally statement.
+  # :ms_asm_stmt ::
+  #   A MS inline assembly statement extension.
   # :null_stmt ::
   #   The null satement ";": C99 6.8.3p3.
   #   
@@ -1530,6 +1922,38 @@ module FFIGen::Clang
   # :decl_stmt ::
   #   Adaptor class for mixing declarations with statements and
   #   expressions.
+  # :omp_parallel_directive ::
+  #   OpenMP parallel directive.
+  # :omp_simd_directive ::
+  #   OpenMP simd directive.
+  # :omp_for_directive ::
+  #   OpenMP for directive.
+  # :omp_sections_directive ::
+  #   OpenMP sections directive.
+  # :omp_section_directive ::
+  #   OpenMP section directive.
+  # :omp_single_directive ::
+  #   OpenMP single directive.
+  # :omp_parallel_for_directive ::
+  #   OpenMP parallel for directive.
+  # :omp_parallel_sections_directive ::
+  #   OpenMP parallel sections directive.
+  # :omp_task_directive ::
+  #   OpenMP task directive.
+  # :omp_master_directive ::
+  #   OpenMP master directive.
+  # :omp_critical_directive ::
+  #   OpenMP critical directive.
+  # :omp_taskyield_directive ::
+  #   OpenMP taskyield directive.
+  # :omp_barrier_directive ::
+  #   OpenMP barrier directive.
+  # :omp_taskwait_directive ::
+  #   OpenMP taskwait directive.
+  # :omp_flush_directive ::
+  #   OpenMP flush directive.
+  # :seh_leave_stmt ::
+  #   Windows Structured Exception Handling's leave statement.
   # :translation_unit ::
   #   Cursor that represents the translation unit itself.
   #   
@@ -1546,11 +1970,29 @@ module FFIGen::Clang
   #   
   # :ib_outlet_collection_attr ::
   #   
-  # :x_final_attr ::
+  # :cxx_final_attr ::
   #   
-  # :x_override_attr ::
+  # :cxx_override_attr ::
   #   
   # :annotate_attr ::
+  #   
+  # :asm_label_attr ::
+  #   
+  # :packed_attr ::
+  #   
+  # :pure_attr ::
+  #   
+  # :const_attr ::
+  #   
+  # :no_duplicate_attr ::
+  #   
+  # :cuda_constant_attr ::
+  #   
+  # :cuda_device_attr ::
+  #   
+  # :cuda_global_attr ::
+  #   
+  # :cuda_host_attr ::
   #   
   # :preprocessing_directive ::
   #   Preprocessing
@@ -1560,6 +2002,8 @@ module FFIGen::Clang
   #   
   # :inclusion_directive ::
   #   
+  # :module_import_decl ::
+  #   A module import declaration.
   # 
   # @method _enum_cursor_kind_
   # @return [Symbol]
@@ -1585,7 +2029,7 @@ module FFIGen::Clang
     :obj_c_implementation_decl, 18,
     :obj_c_category_impl_decl, 19,
     :typedef_decl, 20,
-    :x_method, 21,
+    :cxx_method, 21,
     :namespace, 22,
     :linkage_spec, 23,
     :constructor, 24,
@@ -1603,18 +2047,19 @@ module FFIGen::Clang
     :type_alias_decl, 36,
     :obj_c_synthesize_decl, 37,
     :obj_c_dynamic_decl, 38,
-    :x_access_specifier, 39,
+    :cxx_access_specifier, 39,
     :first_ref, 40,
     :obj_c_super_class_ref, 40,
     :obj_c_protocol_ref, 41,
     :obj_c_class_ref, 42,
     :type_ref, 43,
-    :x_base_specifier, 44,
+    :cxx_base_specifier, 44,
     :template_ref, 45,
     :namespace_ref, 46,
     :member_ref, 47,
     :label_ref, 48,
     :overloaded_decl_ref, 49,
+    :variable_ref, 50,
     :first_invalid, 70,
     :invalid_file, 70,
     :no_decl_found, 71,
@@ -1645,18 +2090,18 @@ module FFIGen::Clang
     :stmt_expr, 121,
     :generic_selection_expr, 122,
     :gnu_null_expr, 123,
-    :x_static_cast_expr, 124,
-    :x_dynamic_cast_expr, 125,
-    :x_reinterpret_cast_expr, 126,
-    :x_const_cast_expr, 127,
-    :x_functional_cast_expr, 128,
-    :x_typeid_expr, 129,
-    :x_bool_literal_expr, 130,
-    :x_null_ptr_literal_expr, 131,
-    :x_this_expr, 132,
-    :x_throw_expr, 133,
-    :x_new_expr, 134,
-    :x_delete_expr, 135,
+    :cxx_static_cast_expr, 124,
+    :cxx_dynamic_cast_expr, 125,
+    :cxx_reinterpret_cast_expr, 126,
+    :cxx_const_cast_expr, 127,
+    :cxx_functional_cast_expr, 128,
+    :cxx_typeid_expr, 129,
+    :cxx_bool_literal_expr, 130,
+    :cxx_null_ptr_literal_expr, 131,
+    :cxx_this_expr, 132,
+    :cxx_throw_expr, 133,
+    :cxx_new_expr, 134,
+    :cxx_delete_expr, 135,
     :unary_expr, 136,
     :obj_c_string_literal, 137,
     :obj_c_encode_expr, 138,
@@ -1665,6 +2110,9 @@ module FFIGen::Clang
     :obj_c_bridged_cast_expr, 141,
     :pack_expansion_expr, 142,
     :size_of_pack_expr, 143,
+    :lambda_expr, 144,
+    :obj_c_bool_literal_expr, 145,
+    :obj_c_self_expr, 146,
     :first_stmt, 200,
     :unexposed_stmt, 200,
     :label_stmt, 201,
@@ -1681,7 +2129,7 @@ module FFIGen::Clang
     :continue_stmt, 212,
     :break_stmt, 213,
     :return_stmt, 214,
-    :asm_stmt, 215,
+    :gcc_asm_stmt, 215,
     :obj_c_at_try_stmt, 216,
     :obj_c_at_catch_stmt, 217,
     :obj_c_at_finally_stmt, 218,
@@ -1689,27 +2137,54 @@ module FFIGen::Clang
     :obj_c_at_synchronized_stmt, 220,
     :obj_c_autorelease_pool_stmt, 221,
     :obj_c_for_collection_stmt, 222,
-    :x_catch_stmt, 223,
-    :x_try_stmt, 224,
-    :x_for_range_stmt, 225,
+    :cxx_catch_stmt, 223,
+    :cxx_try_stmt, 224,
+    :cxx_for_range_stmt, 225,
     :seh_try_stmt, 226,
     :seh_except_stmt, 227,
     :seh_finally_stmt, 228,
+    :ms_asm_stmt, 229,
     :null_stmt, 230,
     :decl_stmt, 231,
+    :omp_parallel_directive, 232,
+    :omp_simd_directive, 233,
+    :omp_for_directive, 234,
+    :omp_sections_directive, 235,
+    :omp_section_directive, 236,
+    :omp_single_directive, 237,
+    :omp_parallel_for_directive, 238,
+    :omp_parallel_sections_directive, 239,
+    :omp_task_directive, 240,
+    :omp_master_directive, 241,
+    :omp_critical_directive, 242,
+    :omp_taskyield_directive, 243,
+    :omp_barrier_directive, 244,
+    :omp_taskwait_directive, 245,
+    :omp_flush_directive, 246,
+    :seh_leave_stmt, 247,
     :translation_unit, 300,
     :first_attr, 400,
     :unexposed_attr, 400,
     :ib_action_attr, 401,
     :ib_outlet_attr, 402,
     :ib_outlet_collection_attr, 403,
-    :x_final_attr, 404,
-    :x_override_attr, 405,
+    :cxx_final_attr, 404,
+    :cxx_override_attr, 405,
     :annotate_attr, 406,
+    :asm_label_attr, 407,
+    :packed_attr, 408,
+    :pure_attr, 409,
+    :const_attr, 410,
+    :no_duplicate_attr, 411,
+    :cuda_constant_attr, 412,
+    :cuda_device_attr, 413,
+    :cuda_global_attr, 414,
+    :cuda_host_attr, 415,
     :preprocessing_directive, 500,
     :macro_definition, 501,
     :macro_expansion, 502,
-    :inclusion_directive, 503
+    :inclusion_directive, 503,
+    :module_import_decl, 600
   ]
   
   # A cursor representing some element in the abstract syntax tree for
@@ -1769,7 +2244,7 @@ module FFIGen::Clang
   # @scope class
   attach_function :equal_cursors, :clang_equalCursors, [Cursor.by_value, Cursor.by_value], :uint
   
-  # Returns non-zero if \arg cursor is null.
+  # Returns non-zero if \p cursor is null.
   # 
   # @method cursor_is_null(cursor)
   # @param [Cursor] cursor 
@@ -1897,11 +2372,11 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :linkage_kind, [
-    :invalid,
-    :no_linkage,
-    :internal,
-    :unique_external,
-    :external
+    :invalid, 0,
+    :no_linkage, 1,
+    :internal, 2,
+    :unique_external, 3,
+    :external, 4
   ]
   
   # Determine the linkage of the entity referred to by a given cursor.
@@ -1912,13 +2387,84 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_cursor_linkage, :clang_getCursorLinkage, [Cursor.by_value], :linkage_kind
   
-  # Determine the availability of the entity that this cursor refers to.
+  # Determine the availability of the entity that this cursor refers to,
+  # taking the current target platform into account.
   # 
   # @method get_cursor_availability(cursor)
   # @param [Cursor] cursor The cursor to query.
   # @return [Symbol from _enum_availability_kind_] The availability of the cursor.
   # @scope class
   attach_function :get_cursor_availability, :clang_getCursorAvailability, [Cursor.by_value], :availability_kind
+  
+  # Describes the availability of a given entity on a particular platform, e.g.,
+  # a particular class might only be available on Mac OS 10.7 or newer.
+  # 
+  # = Fields:
+  # :platform ::
+  #   (String) A string that describes the platform for which this structure
+  #   provides availability information.
+  #   
+  #   Possible values are "ios" or "macosx".
+  # :introduced ::
+  #   (Version) The version number in which this entity was introduced.
+  # :deprecated ::
+  #   (Version) The version number in which this entity was deprecated (but is
+  #   still available).
+  # :obsoleted ::
+  #   (Version) The version number in which this entity was obsoleted, and therefore
+  #   is no longer available.
+  # :unavailable ::
+  #   (Integer) Whether the entity is unconditionally unavailable on this platform.
+  # :message ::
+  #   (String) An optional message to provide to a user of this API, e.g., to
+  #   suggest replacement APIs.
+  class PlatformAvailability < FFI::Struct
+    layout :platform, String.by_value,
+           :introduced, Version.by_value,
+           :deprecated, Version.by_value,
+           :obsoleted, Version.by_value,
+           :unavailable, :int,
+           :message, String.by_value
+  end
+  
+  # Determine the availability of the entity that this cursor refers to
+  # on any platforms for which availability information is known.
+  # 
+  # @method get_cursor_platform_availability(cursor, always_deprecated, deprecated_message, always_unavailable, unavailable_message, availability, availability_size)
+  # @param [Cursor] cursor The cursor to query.
+  # @param [FFI::Pointer(*Int)] always_deprecated If non-NULL, will be set to indicate whether the 
+  #   entity is deprecated on all platforms.
+  # @param [String] deprecated_message If non-NULL, will be set to the message text 
+  #   provided along with the unconditional deprecation of this entity. The client
+  #   is responsible for deallocating this string.
+  # @param [FFI::Pointer(*Int)] always_unavailable If non-NULL, will be set to indicate whether the
+  #   entity is unavailable on all platforms.
+  # @param [String] unavailable_message If non-NULL, will be set to the message text
+  #   provided along with the unconditional unavailability of this entity. The 
+  #   client is responsible for deallocating this string.
+  # @param [PlatformAvailability] availability If non-NULL, an array of CXPlatformAvailability instances
+  #   that will be populated with platform availability information, up to either
+  #   the number of platforms for which availability information is available (as
+  #   returned by this function) or \c availability_size, whichever is smaller.
+  # @param [Integer] availability_size The number of elements available in the 
+  #   \c availability array.
+  # @return [Integer] The number of platforms (N) for which availability information is
+  #   available (which is unrelated to \c availability_size).
+  #   
+  #   Note that the client is responsible for calling 
+  #   \c clang_disposeCXPlatformAvailability to free each of the 
+  #   platform-availability structures returned. There are 
+  #   \c min(N, availability_size) such structures.
+  # @scope class
+  attach_function :get_cursor_platform_availability, :clang_getCursorPlatformAvailability, [Cursor.by_value, :pointer, String, :pointer, String, PlatformAvailability, :int], :int
+  
+  # Free the memory associated with a \c CXPlatformAvailability structure.
+  # 
+  # @method dispose_cx_platform_availability(availability)
+  # @param [PlatformAvailability] availability 
+  # @return [nil] 
+  # @scope class
+  attach_function :dispose_cx_platform_availability, :clang_disposeCXPlatformAvailability, [PlatformAvailability], :void
   
   # Describe the "language" of the entity referred to by a cursor.
   # 
@@ -1939,9 +2485,9 @@ module FFIGen::Clang
   # @scope class
   enum :language_kind, [
     :invalid, 0,
-    :c,
-    :obj_c,
-    :c_plus_plus
+    :c, 1,
+    :obj_c, 2,
+    :c_plus_plus, 3
   ]
   
   # Determine the "language" of the entity referred to by a given cursor.
@@ -2014,10 +2560,10 @@ module FFIGen::Clang
   # void C::f() { }
   # \endcode
   # 
-  # In the out-of-line definition of \c C::f, the semantic parent is the 
+  # In the out-of-line definition of \c C::f, the semantic parent is
   # the class \c C, of which this function is a member. The lexical parent is
   # the place where the declaration actually occurs in the source code; in this
-  # case, the definition occurs in the translation unit. In general, the 
+  # case, the definition occurs in the translation unit. In general, the
   # lexical parent for a given entity can change without affecting the semantics
   # of the program, and the lexical parent of different declarations of the
   # same entity may be different. Changing the semantic parent of a declaration,
@@ -2052,10 +2598,10 @@ module FFIGen::Clang
   # void C::f() { }
   # \endcode
   # 
-  # In the out-of-line definition of \c C::f, the semantic parent is the 
+  # In the out-of-line definition of \c C::f, the semantic parent is
   # the class \c C, of which this function is a member. The lexical parent is
   # the place where the declaration actually occurs in the source code; in this
-  # case, the definition occurs in the translation unit. In general, the 
+  # case, the definition occurs in the translation unit. In general, the
   # lexical parent for a given entity can change without affecting the semantics
   # of the program, and the lexical parent of different declarations of the
   # same entity may be different. Changing the semantic parent of a declaration,
@@ -2081,11 +2627,12 @@ module FFIGen::Clang
   # In both Objective-C and C++, a method (aka virtual member function,
   # in C++) can override a virtual method in a base class. For
   # Objective-C, a method is said to override any method in the class's
-  # interface (if we're coming from an implementation), its protocols,
-  # or its categories, that has the same selector and is of the same
-  # kind (class or instance). If no such method exists, the search
-  # continues to the class's superclass, its protocols, and its
-  # categories, and so on.
+  # base class, its protocols, or its categories' protocols, that has the same
+  # selector and is of the same kind (class or instance).
+  # If no such method exists, the search continues to the class's superclass,
+  # its protocols, and its categories, and so on. A method from an Objective-C
+  # implementation is considered to override the same methods as its
+  # corresponding method in the interface.
   # 
   # For C++, a virtual member function overrides any virtual member
   # function with the same signature that occurs in its base
@@ -2175,7 +2722,7 @@ module FFIGen::Clang
   # 
   # The extent of a cursor starts with the file/line/column pointing at the
   # first character within the source construct that the cursor refers to and
-  # ends with the last character withinin that source construct. For a
+  # ends with the last character within that source construct. For a
   # declaration, the extent covers the declaration itself. For a reference,
   # the extent covers the location of the reference (e.g., where the referenced
   # entity was actually used).
@@ -2192,7 +2739,7 @@ module FFIGen::Clang
   # 
   # === Options:
   # :invalid ::
-  #   Reprents an invalid type (e.g., where no type is available).
+  #   Represents an invalid type (e.g., where no type is available).
   # :unexposed ::
   #   A type whose specific kind is not exposed via this
   #   interface.
@@ -2278,6 +2825,16 @@ module FFIGen::Clang
   #   
   # :constant_array ::
   #   
+  # :vector ::
+  #   
+  # :incomplete_array ::
+  #   
+  # :variable_array ::
+  #   
+  # :dependent_sized_array ::
+  #   
+  # :member_pointer ::
+  #   
   # 
   # @method _enum_type_kind_
   # @return [Symbol]
@@ -2325,7 +2882,66 @@ module FFIGen::Clang
     :obj_c_object_pointer, 109,
     :function_no_proto, 110,
     :function_proto, 111,
-    :constant_array, 112
+    :constant_array, 112,
+    :vector, 113,
+    :incomplete_array, 114,
+    :variable_array, 115,
+    :dependent_sized_array, 116,
+    :member_pointer, 117
+  ]
+  
+  # Describes the calling convention of a function type
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:calling_conv).</em>
+  # 
+  # === Options:
+  # :default ::
+  #   
+  # :c ::
+  #   
+  # :x86_std_call ::
+  #   
+  # :x86_fast_call ::
+  #   
+  # :x86_this_call ::
+  #   
+  # :x86_pascal ::
+  #   
+  # :aapcs ::
+  #   
+  # :aapcs_vfp ::
+  #   
+  # :pnacl_call ::
+  #   
+  # :intel_ocl_bicc ::
+  #   
+  # :x86_64_win64 ::
+  #   
+  # :x86_64_sys_v ::
+  #   
+  # :invalid ::
+  #   
+  # :unexposed ::
+  #   
+  # 
+  # @method _enum_calling_conv_
+  # @return [Symbol]
+  # @scope class
+  enum :calling_conv, [
+    :default, 0,
+    :c, 1,
+    :x86_std_call, 2,
+    :x86_fast_call, 3,
+    :x86_this_call, 4,
+    :x86_pascal, 5,
+    :aapcs, 6,
+    :aapcs_vfp, 7,
+    :pnacl_call, 8,
+    :intel_ocl_bicc, 9,
+    :x86_64_win64, 10,
+    :x86_64_sys_v, 11,
+    :invalid, 100,
+    :unexposed, 200
   ]
   
   # The type of an element in the abstract syntax tree.
@@ -2348,13 +2964,107 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_cursor_type, :clang_getCursorType, [Cursor.by_value], Type.by_value
   
+  # Pretty-print the underlying type using the rules of the
+  # language of the translation unit from which it came.
+  # 
+  # If the type is invalid, an empty string is returned.
+  # 
+  # @method get_type_spelling(ct)
+  # @param [Type] ct 
+  # @return [String] 
+  # @scope class
+  attach_function :get_type_spelling, :clang_getTypeSpelling, [Type.by_value], String.by_value
+  
+  # Retrieve the underlying type of a typedef declaration.
+  # 
+  # If the cursor does not reference a typedef declaration, an invalid type is
+  # returned.
+  # 
+  # @method get_typedef_decl_underlying_type(c)
+  # @param [Cursor] c 
+  # @return [Type] 
+  # @scope class
+  attach_function :get_typedef_decl_underlying_type, :clang_getTypedefDeclUnderlyingType, [Cursor.by_value], Type.by_value
+  
+  # Retrieve the integer type of an enum declaration.
+  # 
+  # If the cursor does not reference an enum declaration, an invalid type is
+  # returned.
+  # 
+  # @method get_enum_decl_integer_type(c)
+  # @param [Cursor] c 
+  # @return [Type] 
+  # @scope class
+  attach_function :get_enum_decl_integer_type, :clang_getEnumDeclIntegerType, [Cursor.by_value], Type.by_value
+  
+  # Retrieve the integer value of an enum constant declaration as a signed
+  #  long long.
+  # 
+  # If the cursor does not reference an enum constant declaration, LLONG_MIN is returned.
+  # Since this is also potentially a valid constant value, the kind of the cursor
+  # must be verified before calling this function.
+  # 
+  # @method get_enum_constant_decl_value(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_enum_constant_decl_value, :clang_getEnumConstantDeclValue, [Cursor.by_value], :long_long
+  
+  # Retrieve the integer value of an enum constant declaration as an unsigned
+  #  long long.
+  # 
+  # If the cursor does not reference an enum constant declaration, ULLONG_MAX is returned.
+  # Since this is also potentially a valid constant value, the kind of the cursor
+  # must be verified before calling this function.
+  # 
+  # @method get_enum_constant_decl_unsigned_value(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_enum_constant_decl_unsigned_value, :clang_getEnumConstantDeclUnsignedValue, [Cursor.by_value], :ulong_long
+  
+  # Retrieve the bit width of a bit field declaration as an integer.
+  # 
+  # If a cursor that is not a bit field declaration is passed in, -1 is returned.
+  # 
+  # @method get_field_decl_bit_width(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_field_decl_bit_width, :clang_getFieldDeclBitWidth, [Cursor.by_value], :int
+  
+  # Retrieve the number of non-variadic arguments associated with a given
+  # cursor.
+  # 
+  # The number of arguments can be determined for calls as well as for
+  # declarations of functions or methods. For other cursors -1 is returned.
+  # 
+  # @method cursor_get_num_arguments(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_get_num_arguments, :clang_Cursor_getNumArguments, [Cursor.by_value], :int
+  
+  # Retrieve the argument cursor of a function or method.
+  # 
+  # The argument cursor can be determined for calls as well as for declarations
+  # of functions or methods. For other cursors and for invalid indices, an
+  # invalid cursor is returned.
+  # 
+  # @method cursor_get_argument(c, i)
+  # @param [Cursor] c 
+  # @param [Integer] i 
+  # @return [Cursor] 
+  # @scope class
+  attach_function :cursor_get_argument, :clang_Cursor_getArgument, [Cursor.by_value, :uint], Cursor.by_value
+  
   # Determine whether two CXTypes represent the same type.
   # 
   # @method equal_types(a, b)
   # @param [Type] a 
   # @param [Type] b 
-  # @return [Integer] non-zero if the CXTypes represent the same type and 
-  #               zero otherwise.
+  # @return [Integer] non-zero if the CXTypes represent the same type and
+  #            zero otherwise.
   # @scope class
   attach_function :equal_types, :clang_equalTypes, [Type.by_value, Type.by_value], :uint
   
@@ -2371,8 +3081,9 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_canonical_type, :clang_getCanonicalType, [Type.by_value], Type.by_value
   
-  #  Determine whether a CXType has the "const" qualifier set, 
-  #  without looking through typedefs that may have added "const" at a different level.
+  # Determine whether a CXType has the "const" qualifier set,
+  # without looking through typedefs that may have added "const" at a
+  # different level.
   # 
   # @method is_const_qualified_type(t)
   # @param [Type] t 
@@ -2380,8 +3091,9 @@ module FFIGen::Clang
   # @scope class
   attach_function :is_const_qualified_type, :clang_isConstQualifiedType, [Type.by_value], :uint
   
-  #  Determine whether a CXType has the "volatile" qualifier set,
-  #  without looking through typedefs that may have added "volatile" at a different level.
+  # Determine whether a CXType has the "volatile" qualifier set,
+  # without looking through typedefs that may have added "volatile" at
+  # a different level.
   # 
   # @method is_volatile_qualified_type(t)
   # @param [Type] t 
@@ -2389,8 +3101,9 @@ module FFIGen::Clang
   # @scope class
   attach_function :is_volatile_qualified_type, :clang_isVolatileQualifiedType, [Type.by_value], :uint
   
-  #  Determine whether a CXType has the "restrict" qualifier set,
-  #  without looking through typedefs that may have added "restrict" at a different level.
+  # Determine whether a CXType has the "restrict" qualifier set,
+  # without looking through typedefs that may have added "restrict" at a
+  # different level.
   # 
   # @method is_restrict_qualified_type(t)
   # @param [Type] t 
@@ -2430,7 +3143,19 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_type_kind_spelling, :clang_getTypeKindSpelling, [:type_kind], String.by_value
   
-  # Retrieve the result type associated with a function type.
+  # Retrieve the calling convention associated with a function type.
+  # 
+  # If a non-function type is passed in, CXCallingConv_Invalid is returned.
+  # 
+  # @method get_function_type_calling_conv(t)
+  # @param [Type] t 
+  # @return [Symbol from _enum_calling_conv_] 
+  # @scope class
+  attach_function :get_function_type_calling_conv, :clang_getFunctionTypeCallingConv, [Type.by_value], :calling_conv
+  
+  # Retrieve the return type associated with a function type.
+  # 
+  # If a non-function type is passed in, an invalid type is returned.
   # 
   # @method get_result_type(t)
   # @param [Type] t 
@@ -2438,8 +3163,40 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_result_type, :clang_getResultType, [Type.by_value], Type.by_value
   
-  # Retrieve the result type associated with a given cursor.  This only
-  #  returns a valid type of the cursor refers to a function or method.
+  # Retrieve the number of non-variadic parameters associated with a
+  # function type.
+  # 
+  # If a non-function type is passed in, -1 is returned.
+  # 
+  # @method get_num_arg_types(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_num_arg_types, :clang_getNumArgTypes, [Type.by_value], :int
+  
+  # Retrieve the type of a parameter of a function type.
+  # 
+  # If a non-function type is passed in or the function does not have enough
+  # parameters, an invalid type is returned.
+  # 
+  # @method get_arg_type(t, i)
+  # @param [Type] t 
+  # @param [Integer] i 
+  # @return [Type] 
+  # @scope class
+  attach_function :get_arg_type, :clang_getArgType, [Type.by_value, :uint], Type.by_value
+  
+  # Return 1 if the CXType is a variadic function type, and 0 otherwise.
+  # 
+  # @method is_function_type_variadic(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :is_function_type_variadic, :clang_isFunctionTypeVariadic, [Type.by_value], :uint
+  
+  # Retrieve the return type associated with a given cursor.
+  # 
+  # This only returns a valid type if the cursor refers to a function or method.
   # 
   # @method get_cursor_result_type(c)
   # @param [Cursor] c 
@@ -2456,6 +3213,28 @@ module FFIGen::Clang
   # @scope class
   attach_function :is_pod_type, :clang_isPODType, [Type.by_value], :uint
   
+  # Return the element type of an array, complex, or vector type.
+  # 
+  # If a type is passed in that is not an array, complex, or vector type,
+  # an invalid type is returned.
+  # 
+  # @method get_element_type(t)
+  # @param [Type] t 
+  # @return [Type] 
+  # @scope class
+  attach_function :get_element_type, :clang_getElementType, [Type.by_value], Type.by_value
+  
+  # Return the number of elements of an array or vector type.
+  # 
+  # If a type is passed in that is not an array or vector type,
+  # -1 is returned.
+  # 
+  # @method get_num_elements(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_num_elements, :clang_getNumElements, [Type.by_value], :long_long
+  
   # Return the element type of an array type.
   # 
   # If a non-array type is passed in, an invalid type is returned.
@@ -2466,7 +3245,7 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_array_element_type, :clang_getArrayElementType, [Type.by_value], Type.by_value
   
-  # Return the the array size of a constant array.
+  # Return the array size of a constant array.
   # 
   # If a non-array type is passed in, -1 is returned.
   # 
@@ -2475,6 +3254,164 @@ module FFIGen::Clang
   # @return [Integer] 
   # @scope class
   attach_function :get_array_size, :clang_getArraySize, [Type.by_value], :long_long
+  
+  # List the possible error codes for \c clang_Type_getSizeOf,
+  #   \c clang_Type_getAlignOf, \c clang_Type_getOffsetOf and
+  #   \c clang_Cursor_getOffsetOf.
+  # 
+  # A value of this enumeration type can be returned if the target type is not
+  # a valid argument to sizeof, alignof or offsetof.
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:type_layout_error).</em>
+  # 
+  # === Options:
+  # :invalid ::
+  #   Type is of kind CXType_Invalid.
+  # :incomplete ::
+  #   The type is an incomplete Type.
+  # :dependent ::
+  #   The type is a dependent Type.
+  # :not_constant_size ::
+  #   The type is not a constant size type.
+  # :invalid_field_name ::
+  #   The Field name is not valid for this record.
+  # 
+  # @method _enum_type_layout_error_
+  # @return [Symbol]
+  # @scope class
+  enum :type_layout_error, [
+    :invalid, -1,
+    :incomplete, -2,
+    :dependent, -3,
+    :not_constant_size, -4,
+    :invalid_field_name, -5
+  ]
+  
+  # Return the alignment of a type in bytes as per C++(expr.alignof)
+  #   standard.
+  # 
+  # If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+  # If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+  #   is returned.
+  # If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+  #   returned.
+  # If the type declaration is not a constant size type,
+  #   CXTypeLayoutError_NotConstantSize is returned.
+  # 
+  # @method type_get_align_of(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :type_get_align_of, :clang_Type_getAlignOf, [Type.by_value], :long_long
+  
+  # Return the class type of an member pointer type.
+  # 
+  # If a non-member-pointer type is passed in, an invalid type is returned.
+  # 
+  # @method type_get_class_type(t)
+  # @param [Type] t 
+  # @return [Type] 
+  # @scope class
+  attach_function :type_get_class_type, :clang_Type_getClassType, [Type.by_value], Type.by_value
+  
+  # Return the size of a type in bytes as per C++(expr.sizeof) standard.
+  # 
+  # If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+  # If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+  #   is returned.
+  # If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+  #   returned.
+  # 
+  # @method type_get_size_of(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :type_get_size_of, :clang_Type_getSizeOf, [Type.by_value], :long_long
+  
+  # Return the offset of a field named S in a record of type T in bits
+  #   as it would be returned by __offsetof__ as per C++11(18.2p4)
+  # 
+  # If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
+  #   is returned.
+  # If the field's type declaration is an incomplete type,
+  #   CXTypeLayoutError_Incomplete is returned.
+  # If the field's type declaration is a dependent type,
+  #   CXTypeLayoutError_Dependent is returned.
+  # If the field's name S is not found,
+  #   CXTypeLayoutError_InvalidFieldName is returned.
+  # 
+  # @method type_get_offset_of(t, s)
+  # @param [Type] t 
+  # @param [String] s 
+  # @return [Integer] 
+  # @scope class
+  attach_function :type_get_offset_of, :clang_Type_getOffsetOf, [Type.by_value, :string], :long_long
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:ref_qualifier_kind).</em>
+  # 
+  # === Options:
+  # :none ::
+  #   No ref-qualifier was provided.
+  # :l_value ::
+  #   An lvalue ref-qualifier was provided (\c &).
+  # :r_value ::
+  #   An rvalue ref-qualifier was provided (\c &&).
+  # 
+  # @method _enum_ref_qualifier_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :ref_qualifier_kind, [
+    :none, 0,
+    :l_value, 1,
+    :r_value, 2
+  ]
+  
+  # Returns the number of template arguments for given class template
+  # specialization, or -1 if type \c T is not a class template specialization.
+  # 
+  # Variadic argument packs count as only one argument, and can not be inspected
+  # further.
+  # 
+  # @method type_get_num_template_arguments(t)
+  # @param [Type] t 
+  # @return [Integer] 
+  # @scope class
+  attach_function :type_get_num_template_arguments, :clang_Type_getNumTemplateArguments, [Type.by_value], :int
+  
+  # Returns the type template argument of a template class specialization
+  # at given index.
+  # 
+  # This function only returns template type arguments and does not handle
+  # template template arguments or variadic packs.
+  # 
+  # @method type_get_template_argument_as_type(t, i)
+  # @param [Type] t 
+  # @param [Integer] i 
+  # @return [Type] 
+  # @scope class
+  attach_function :type_get_template_argument_as_type, :clang_Type_getTemplateArgumentAsType, [Type.by_value, :uint], Type.by_value
+  
+  # Retrieve the ref-qualifier kind of a function or method.
+  # 
+  # The ref-qualifier is returned for C++ functions or methods. For other types
+  # or non-C++ declarations, CXRefQualifier_None is returned.
+  # 
+  # @method type_get_cxx_ref_qualifier(t)
+  # @param [Type] t 
+  # @return [Symbol from _enum_ref_qualifier_kind_] 
+  # @scope class
+  attach_function :type_get_cxx_ref_qualifier, :clang_Type_getCXXRefQualifier, [Type.by_value], :ref_qualifier_kind
+  
+  # Returns non-zero if the cursor specifies a Record member that is a
+  #   bitfield.
+  # 
+  # @method cursor_is_bit_field(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_is_bit_field, :clang_Cursor_isBitField, [Cursor.by_value], :uint
   
   # Returns 1 if the base class specified by the cursor with kind
   #   CX_CXXBaseSpecifier is virtual.
@@ -2491,28 +3428,30 @@ module FFIGen::Clang
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:cxx_access_specifier).</em>
   # 
   # === Options:
-  # :x_invalid_access_specifier ::
+  # :invalid_access_specifier ::
   #   
-  # :x_public ::
+  # :public ::
   #   
-  # :x_protected ::
+  # :protected ::
   #   
-  # :x_private ::
+  # :private ::
   #   
   # 
   # @method _enum_cxx_access_specifier_
   # @return [Symbol]
   # @scope class
   enum :cxx_access_specifier, [
-    :x_invalid_access_specifier,
-    :x_public,
-    :x_protected,
-    :x_private
+    :invalid_access_specifier, 0,
+    :public, 1,
+    :protected, 2,
+    :private, 3
   ]
   
-  # Returns the access control level for the C++ base specifier
-  # represented by a cursor with kind CXCursor_CXXBaseSpecifier or
-  # CXCursor_AccessSpecifier.
+  # Returns the access control level for the referenced object.
+  # 
+  # If the cursor refers to a C++ declaration, its access control level within its
+  # parent scope is returned. Otherwise, if the cursor refers to a base specifier or
+  # access specifier, the specifier itself is returned.
   # 
   # @method get_cxx_access_specifier(cursor)
   # @param [Cursor] cursor 
@@ -2562,7 +3501,7 @@ module FFIGen::Clang
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:child_visit_result).</em>
   # 
   # === Options:
-  # :break ::
+  # :break_ ::
   #   Terminates the cursor traversal.
   # :continue ::
   #   Continues the cursor traversal with the next sibling of
@@ -2575,9 +3514,9 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :child_visit_result, [
-    :break,
-    :continue,
-    :recurse
+    :break_, 0,
+    :continue, 1,
+    :recurse, 2
   ]
   
   # Visitor invoked for each cursor found by a traversal.
@@ -2700,6 +3639,20 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_cursor_spelling, :clang_getCursorSpelling, [Cursor.by_value], String.by_value
   
+  # Retrieve a range for a piece that forms the cursors spelling name.
+  # Most of the times there is only one range for the complete spelling but for
+  # Objective-C methods and Objective-C message expressions, there are multiple
+  # pieces for each selector identifier.
+  # 
+  # @method cursor_get_spelling_name_range(cursor, piece_index, options)
+  # @param [Cursor] cursor 
+  # @param [Integer] piece_index the index of the spelling name piece. If this is greater
+  #   than the actual number of pieces, it will return a NULL (invalid) range.
+  # @param [Integer] options Reserved.
+  # @return [SourceRange] 
+  # @scope class
+  attach_function :cursor_get_spelling_name_range, :clang_Cursor_getSpellingNameRange, [Cursor.by_value, :uint, :uint], SourceRange.by_value
+  
   # Retrieve the display name for the entity referenced by this cursor.
   # 
   # The display name contains extra information that helps identify the cursor,
@@ -2728,32 +3681,32 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_cursor_referenced, :clang_getCursorReferenced, [Cursor.by_value], Cursor.by_value
   
-  #  For a cursor that is either a reference to or a declaration
-  #  of some entity, retrieve a cursor that describes the definition of
-  #  that entity.
+  # For a cursor that is either a reference to or a declaration
+  # of some entity, retrieve a cursor that describes the definition of
+  # that entity.
   # 
-  #  Some entities can be declared multiple times within a translation
-  #  unit, but only one of those declarations can also be a
-  #  definition. For example, given:
+  # Some entities can be declared multiple times within a translation
+  # unit, but only one of those declarations can also be a
+  # definition. For example, given:
   # 
-  #  \code
-  #  int f(int, int);
-  #  int g(int x, int y) { return f(x, y); }
-  #  int f(int a, int b) { return a + b; }
-  #  int f(int, int);
-  #  \endcode
+  # \code
+  # int f(int, int);
+  # int g(int x, int y) { return f(x, y); }
+  # int f(int a, int b) { return a + b; }
+  # int f(int, int);
+  # \endcode
   # 
-  #  there are three declarations of the function "f", but only the
-  #  second one is a definition. The clang_getCursorDefinition()
-  #  function will take any cursor pointing to a declaration of "f"
-  #  (the first or fourth lines of the example) or a cursor referenced
-  #  that uses "f" (the call to "f' inside "g") and will return a
-  #  declaration cursor pointing to the definition (the second "f"
-  #  declaration).
+  # there are three declarations of the function "f", but only the
+  # second one is a definition. The clang_getCursorDefinition()
+  # function will take any cursor pointing to a declaration of "f"
+  # (the first or fourth lines of the example) or a cursor referenced
+  # that uses "f" (the call to "f' inside "g") and will return a
+  # declaration cursor pointing to the definition (the second "f"
+  # declaration).
   # 
-  #  If given a cursor for which there is no corresponding definition,
-  #  e.g., because there is no definition of that entity within this
-  #  translation unit, returns a NULL cursor.
+  # If given a cursor for which there is no corresponding definition,
+  # e.g., because there is no definition of that entity within this
+  # translation unit, returns a NULL cursor.
   # 
   # @method get_cursor_definition(cursor)
   # @param [Cursor] cursor 
@@ -2797,6 +3750,287 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_canonical_cursor, :clang_getCanonicalCursor, [Cursor.by_value], Cursor.by_value
   
+  # If the cursor points to a selector identifier in an Objective-C
+  # method or message expression, this returns the selector index.
+  # 
+  # After getting a cursor with #clang_getCursor, this can be called to
+  # determine if the location points to a selector identifier.
+  # 
+  # @method cursor_get_obj_c_selector_index(cursor)
+  # @param [Cursor] cursor 
+  # @return [Integer] The selector index if the cursor is an Objective-C method or message
+  #   expression and the cursor is pointing to a selector identifier, or -1
+  #   otherwise.
+  # @scope class
+  attach_function :cursor_get_obj_c_selector_index, :clang_Cursor_getObjCSelectorIndex, [Cursor.by_value], :int
+  
+  # Given a cursor pointing to a C++ method call or an Objective-C
+  # message, returns non-zero if the method/message is "dynamic", meaning:
+  # 
+  # For a C++ method: the call is virtual.
+  # For an Objective-C message: the receiver is an object instance, not 'super'
+  # or a specific class.
+  # 
+  # If the method/message is "static" or the cursor does not point to a
+  # method/message, it will return zero.
+  # 
+  # @method cursor_is_dynamic_call(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_is_dynamic_call, :clang_Cursor_isDynamicCall, [Cursor.by_value], :int
+  
+  # Given a cursor pointing to an Objective-C message, returns the CXType
+  # of the receiver.
+  # 
+  # @method cursor_get_receiver_type(c)
+  # @param [Cursor] c 
+  # @return [Type] 
+  # @scope class
+  attach_function :cursor_get_receiver_type, :clang_Cursor_getReceiverType, [Cursor.by_value], Type.by_value
+  
+  # Property attributes for a \c CXCursor_ObjCPropertyDecl.
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:obj_c_property_attr_kind).</em>
+  # 
+  # === Options:
+  # :noattr ::
+  #   
+  # :readonly ::
+  #   
+  # :getter ::
+  #   
+  # :assign ::
+  #   
+  # :readwrite ::
+  #   
+  # :retain ::
+  #   
+  # :copy ::
+  #   
+  # :nonatomic ::
+  #   
+  # :setter ::
+  #   
+  # :atomic ::
+  #   
+  # :weak ::
+  #   
+  # :strong ::
+  #   
+  # :unsafe_unretained ::
+  #   
+  # 
+  # @method _enum_obj_c_property_attr_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :obj_c_property_attr_kind, [
+    :noattr, 0,
+    :readonly, 1,
+    :getter, 2,
+    :assign, 4,
+    :readwrite, 8,
+    :retain, 16,
+    :copy, 32,
+    :nonatomic, 64,
+    :setter, 128,
+    :atomic, 256,
+    :weak, 512,
+    :strong, 1024,
+    :unsafe_unretained, 2048
+  ]
+  
+  # Given a cursor that represents a property declaration, return the
+  # associated property attributes. The bits are formed from
+  # \c CXObjCPropertyAttrKind.
+  # 
+  # @method cursor_get_obj_c_property_attributes(c, reserved)
+  # @param [Cursor] c 
+  # @param [Integer] reserved Reserved for future use, pass 0.
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_get_obj_c_property_attributes, :clang_Cursor_getObjCPropertyAttributes, [Cursor.by_value, :uint], :uint
+  
+  # 'Qualifiers' written next to the return and parameter types in
+  # Objective-C method declarations.
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:obj_c_decl_qualifier_kind).</em>
+  # 
+  # === Options:
+  # :none ::
+  #   
+  # :in_ ::
+  #   
+  # :inout ::
+  #   
+  # :out ::
+  #   
+  # :bycopy ::
+  #   
+  # :byref ::
+  #   
+  # :oneway ::
+  #   
+  # 
+  # @method _enum_obj_c_decl_qualifier_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :obj_c_decl_qualifier_kind, [
+    :none, 0,
+    :in_, 1,
+    :inout, 2,
+    :out, 4,
+    :bycopy, 8,
+    :byref, 16,
+    :oneway, 32
+  ]
+  
+  # Given a cursor that represents an Objective-C method or parameter
+  # declaration, return the associated Objective-C qualifiers for the return
+  # type or the parameter respectively. The bits are formed from
+  # CXObjCDeclQualifierKind.
+  # 
+  # @method cursor_get_obj_c_decl_qualifiers(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_get_obj_c_decl_qualifiers, :clang_Cursor_getObjCDeclQualifiers, [Cursor.by_value], :uint
+  
+  # Given a cursor that represents an Objective-C method or property
+  # declaration, return non-zero if the declaration was affected by "@optional".
+  # Returns zero if the cursor is not such a declaration or it is "@required".
+  # 
+  # @method cursor_is_obj_c_optional(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_is_obj_c_optional, :clang_Cursor_isObjCOptional, [Cursor.by_value], :uint
+  
+  # Returns non-zero if the given cursor is a variadic function or method.
+  # 
+  # @method cursor_is_variadic(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cursor_is_variadic, :clang_Cursor_isVariadic, [Cursor.by_value], :uint
+  
+  # Given a cursor that represents a declaration, return the associated
+  # comment's source range.  The range may include multiple consecutive comments
+  # with whitespace in between.
+  # 
+  # @method cursor_get_comment_range(c)
+  # @param [Cursor] c 
+  # @return [SourceRange] 
+  # @scope class
+  attach_function :cursor_get_comment_range, :clang_Cursor_getCommentRange, [Cursor.by_value], SourceRange.by_value
+  
+  # Given a cursor that represents a declaration, return the associated
+  # comment text, including comment markers.
+  # 
+  # @method cursor_get_raw_comment_text(c)
+  # @param [Cursor] c 
+  # @return [String] 
+  # @scope class
+  attach_function :cursor_get_raw_comment_text, :clang_Cursor_getRawCommentText, [Cursor.by_value], String.by_value
+  
+  # Given a cursor that represents a documentable entity (e.g.,
+  # declaration), return the associated \paragraph; otherwise return the
+  # first paragraph.
+  # 
+  # @method cursor_get_brief_comment_text(c)
+  # @param [Cursor] c 
+  # @return [String] 
+  # @scope class
+  attach_function :cursor_get_brief_comment_text, :clang_Cursor_getBriefCommentText, [Cursor.by_value], String.by_value
+  
+  # Given a CXCursor_ModuleImportDecl cursor, return the associated module.
+  # 
+  # @method cursor_get_module(c)
+  # @param [Cursor] c 
+  # @return [FFI::Pointer(Module)] 
+  # @scope class
+  attach_function :cursor_get_module, :clang_Cursor_getModule, [Cursor.by_value], :pointer
+  
+  # Given a CXFile header file, return the module that contains it, if one
+  # exists.
+  # 
+  # @method get_module_for_file(translation_unit_impl, file)
+  # @param [TranslationUnitImpl] translation_unit_impl 
+  # @param [FFI::Pointer(File)] file 
+  # @return [FFI::Pointer(Module)] 
+  # @scope class
+  attach_function :get_module_for_file, :clang_getModuleForFile, [TranslationUnitImpl, :pointer], :pointer
+  
+  # (Not documented)
+  # 
+  # @method module_get_ast_file(module_)
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [FFI::Pointer(File)] the module file where the provided module object came from.
+  # @scope class
+  attach_function :module_get_ast_file, :clang_Module_getASTFile, [:pointer], :pointer
+  
+  # (Not documented)
+  # 
+  # @method module_get_parent(module_)
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [FFI::Pointer(Module)] the parent of a sub-module or NULL if the given module is top-level,
+  #   e.g. for 'std.vector' it will return the 'std' module.
+  # @scope class
+  attach_function :module_get_parent, :clang_Module_getParent, [:pointer], :pointer
+  
+  # (Not documented)
+  # 
+  # @method module_get_name(module_)
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [String] the name of the module, e.g. for the 'std.vector' sub-module it
+  #   will return "vector".
+  # @scope class
+  attach_function :module_get_name, :clang_Module_getName, [:pointer], String.by_value
+  
+  # (Not documented)
+  # 
+  # @method module_get_full_name(module_)
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [String] the full name of the module, e.g. "std.vector".
+  # @scope class
+  attach_function :module_get_full_name, :clang_Module_getFullName, [:pointer], String.by_value
+  
+  # (Not documented)
+  # 
+  # @method module_is_system(module_)
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [Integer] non-zero if the module is a system one.
+  # @scope class
+  attach_function :module_is_system, :clang_Module_isSystem, [:pointer], :int
+  
+  # (Not documented)
+  # 
+  # @method module_get_num_top_level_headers(translation_unit_impl, module_)
+  # @param [TranslationUnitImpl] translation_unit_impl 
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @return [Integer] the number of top level headers associated with this module.
+  # @scope class
+  attach_function :module_get_num_top_level_headers, :clang_Module_getNumTopLevelHeaders, [TranslationUnitImpl, :pointer], :uint
+  
+  # (Not documented)
+  # 
+  # @method module_get_top_level_header(translation_unit_impl, module_, index)
+  # @param [TranslationUnitImpl] translation_unit_impl 
+  # @param [FFI::Pointer(Module)] module_ a module object.
+  # @param [Integer] index top level header index (zero-based).
+  # @return [FFI::Pointer(File)] the specified top level header associated with the module.
+  # @scope class
+  attach_function :module_get_top_level_header, :clang_Module_getTopLevelHeader, [TranslationUnitImpl, :pointer, :uint], :pointer
+  
+  # Determine if a C++ member function or member function template is
+  # pure virtual.
+  # 
+  # @method cxx_method_is_pure_virtual(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cxx_method_is_pure_virtual, :clang_CXXMethod_isPureVirtual, [Cursor.by_value], :uint
+  
   # Determine if a C++ member function or member function template is 
   # declared 'static'.
   # 
@@ -2815,6 +4049,15 @@ module FFIGen::Clang
   # @return [Integer] 
   # @scope class
   attach_function :cxx_method_is_virtual, :clang_CXXMethod_isVirtual, [Cursor.by_value], :uint
+  
+  # Determine if a C++ member function or member function template is
+  # declared 'const'.
+  # 
+  # @method cxx_method_is_const(c)
+  # @param [Cursor] c 
+  # @return [Integer] 
+  # @scope class
+  attach_function :cxx_method_is_const, :clang_CXXMethod_isConst, [Cursor.by_value], :uint
   
   # Given a cursor that represents a template, determine
   # the cursor kind of the specializations would be generated by instantiating
@@ -2875,7 +4118,7 @@ module FFIGen::Clang
   # @param [Integer] piece_index For contiguous names or when passing the flag 
   #   CXNameRange_WantSinglePiece, only one piece with index 0 is 
   #   available. When the CXNameRange_WantSinglePiece flag is not passed for a
-  #   non-contiguous names, this index can be used to retreive the individual
+  #   non-contiguous names, this index can be used to retrieve the individual
   #   pieces of the name. See also CXNameRange_WantSinglePiece.
   # @return [SourceRange] The piece of the name pointed to by the given cursor. If there is no
   #   name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
@@ -2887,19 +4130,19 @@ module FFIGen::Clang
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:name_ref_flags).</em>
   # 
   # === Options:
-  # :want_qualifier ::
+  # :range_want_qualifier ::
   #   Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
   #   range.
-  # :want_template_args ::
-  #   Include the explicit template arguments, e.g. <int> in x.f<int>, in 
-  #   the range.
-  # :want_single_piece ::
+  # :range_want_template_args ::
+  #   Include the explicit template arguments, e.g. \<int> in x.f<int>,
+  #   in the range.
+  # :range_want_single_piece ::
   #   If the name is non-contiguous, return the full spanning range.
   #   
   #   Non-contiguous names occur in Objective-C when a selector with two or more
   #   parameters is used, or in C++ when using an operator:
   #   \code
-  #   (object doSomething:here withValue:there); // ObjC
+  #   (object doSomething:here withValue:there); // Objective-C
   #   return some_vector(1); // C++
   #   \endcode
   # 
@@ -2907,9 +4150,9 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :name_ref_flags, [
-    :want_qualifier, 0x1,
-    :want_template_args, 0x2,
-    :want_single_piece, 0x4
+    :range_want_qualifier, 1,
+    :range_want_template_args, 2,
+    :range_want_single_piece, 4
   ]
   
   # Describes a kind of token.
@@ -2932,11 +4175,11 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :token_kind, [
-    :punctuation,
-    :keyword,
-    :identifier,
-    :literal,
-    :comment
+    :punctuation, 0,
+    :keyword, 1,
+    :identifier, 2,
+    :literal, 3,
+    :comment, 4
   ]
   
   # Describes a single preprocessing token.
@@ -3057,8 +4300,8 @@ module FFIGen::Clang
   # 
   # @method get_definition_spelling_and_extent(cursor, start_buf, end_buf, start_line, start_column, end_line, end_column)
   # @param [Cursor] cursor 
-  # @param [FFI::Pointer(**Char_S)] start_buf 
-  # @param [FFI::Pointer(**Char_S)] end_buf 
+  # @param [FFI::Pointer(**CharS)] start_buf 
+  # @param [FFI::Pointer(**CharS)] end_buf 
   # @param [FFI::Pointer(*UInt)] start_line 
   # @param [FFI::Pointer(*UInt)] start_column 
   # @param [FFI::Pointer(*UInt)] end_line 
@@ -3237,27 +4480,27 @@ module FFIGen::Clang
   # @return [Symbol]
   # @scope class
   enum :completion_chunk_kind, [
-    :optional,
-    :typed_text,
-    :text,
-    :placeholder,
-    :informative,
-    :current_parameter,
-    :left_paren,
-    :right_paren,
-    :left_bracket,
-    :right_bracket,
-    :left_brace,
-    :right_brace,
-    :left_angle,
-    :right_angle,
-    :comma,
-    :result_type,
-    :colon,
-    :semi_colon,
-    :equal,
-    :horizontal_space,
-    :vertical_space
+    :optional, 0,
+    :typed_text, 1,
+    :text, 2,
+    :placeholder, 3,
+    :informative, 4,
+    :current_parameter, 5,
+    :left_paren, 6,
+    :right_paren, 7,
+    :left_bracket, 8,
+    :right_bracket, 9,
+    :left_brace, 10,
+    :right_brace, 11,
+    :left_angle, 12,
+    :right_angle, 13,
+    :comma, 14,
+    :result_type, 15,
+    :colon, 16,
+    :semi_colon, 17,
+    :equal, 18,
+    :horizontal_space, 19,
+    :vertical_space, 20
   ]
   
   # Determine the kind of a particular chunk within a completion string.
@@ -3341,6 +4584,31 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_completion_annotation, :clang_getCompletionAnnotation, [:pointer, :uint], String.by_value
   
+  # Retrieve the parent context of the given completion string.
+  # 
+  # The parent context of a completion string is the semantic parent of 
+  # the declaration (if any) that the code completion represents. For example,
+  # a code completion for an Objective-C method would have the method's class
+  # or protocol as its context.
+  # 
+  # @method get_completion_parent(completion_string, kind)
+  # @param [FFI::Pointer(CompletionString)] completion_string The code completion string whose parent is
+  #   being queried.
+  # @param [FFI::Pointer(*CursorKind)] kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
+  # @return [String] The name of the completion parent, e.g., "NSObject" if
+  #   the completion string represents a method in the NSObject class.
+  # @scope class
+  attach_function :get_completion_parent, :clang_getCompletionParent, [:pointer, :pointer], String.by_value
+  
+  # Retrieve the brief documentation comment attached to the declaration
+  # that corresponds to the given completion string.
+  # 
+  # @method get_completion_brief_comment(completion_string)
+  # @param [FFI::Pointer(CompletionString)] completion_string 
+  # @return [String] 
+  # @scope class
+  attach_function :get_completion_brief_comment, :clang_getCompletionBriefComment, [:pointer], String.by_value
+  
   # Retrieve a completion string for an arbitrary declaration or macro
   # definition cursor.
   # 
@@ -3383,13 +4651,17 @@ module FFIGen::Clang
   # :include_code_patterns ::
   #   Whether to include code patterns for language constructs
   #   within the set of code completions, e.g., for loops.
+  # :include_brief_comments ::
+  #   Whether to include brief documentation within the set of code
+  #   completions returned.
   # 
   # @method _enum_code_complete_flags_
   # @return [Symbol]
   # @scope class
   enum :code_complete_flags, [
-    :include_macros, 0x01,
-    :include_code_patterns, 0x02
+    :include_macros, 1,
+    :include_code_patterns, 2,
+    :include_brief_comments, 4
   ]
   
   # Bits that represent the context under which completion is occurring.
@@ -3400,15 +4672,100 @@ module FFIGen::Clang
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:completion_context).</em>
   # 
   # === Options:
-  # :completion_context_unexposed ::
+  # :unexposed ::
   #   The context for completions is unexposed, as only Clang results
   #   should be included. (This is equivalent to having no context bits set.)
+  # :any_type ::
+  #   Completions for any possible type should be included in the results.
+  # :any_value ::
+  #   Completions for any possible value (variables, function calls, etc.)
+  #   should be included in the results.
+  # :obj_c_object_value ::
+  #   Completions for values that resolve to an Objective-C object should
+  #   be included in the results.
+  # :obj_c_selector_value ::
+  #   Completions for values that resolve to an Objective-C selector
+  #   should be included in the results.
+  # :cxx_class_type_value ::
+  #   Completions for values that resolve to a C++ class type should be
+  #   included in the results.
+  # :dot_member_access ::
+  #   Completions for fields of the member being accessed using the dot
+  #   operator should be included in the results.
+  # :arrow_member_access ::
+  #   Completions for fields of the member being accessed using the arrow
+  #   operator should be included in the results.
+  # :obj_c_property_access ::
+  #   Completions for properties of the Objective-C object being accessed
+  #   using the dot operator should be included in the results.
+  # :enum_tag ::
+  #   Completions for enum tags should be included in the results.
+  # :union_tag ::
+  #   Completions for union tags should be included in the results.
+  # :struct_tag ::
+  #   Completions for struct tags should be included in the results.
+  # :class_tag ::
+  #   Completions for C++ class names should be included in the results.
+  # :namespace ::
+  #   Completions for C++ namespaces and namespace aliases should be
+  #   included in the results.
+  # :nested_name_specifier ::
+  #   Completions for C++ nested name specifiers should be included in
+  #   the results.
+  # :obj_c_interface ::
+  #   Completions for Objective-C interfaces (classes) should be included
+  #   in the results.
+  # :obj_c_protocol ::
+  #   Completions for Objective-C protocols should be included in
+  #   the results.
+  # :obj_c_category ::
+  #   Completions for Objective-C categories should be included in
+  #   the results.
+  # :obj_c_instance_message ::
+  #   Completions for Objective-C instance messages should be included
+  #   in the results.
+  # :obj_c_class_message ::
+  #   Completions for Objective-C class messages should be included in
+  #   the results.
+  # :obj_c_selector_name ::
+  #   Completions for Objective-C selector names should be included in
+  #   the results.
+  # :macro_name ::
+  #   Completions for preprocessor macro names should be included in
+  #   the results.
+  # :natural_language ::
+  #   Natural language completions should be included in the results.
+  # :unknown ::
+  #   The current context is unknown, so set all contexts.
   # 
   # @method _enum_completion_context_
   # @return [Symbol]
   # @scope class
   enum :completion_context, [
-    :completion_context_unexposed, 0
+    :unexposed, 0,
+    :any_type, 1,
+    :any_value, 2,
+    :obj_c_object_value, 4,
+    :obj_c_selector_value, 8,
+    :cxx_class_type_value, 16,
+    :dot_member_access, 32,
+    :arrow_member_access, 64,
+    :obj_c_property_access, 128,
+    :enum_tag, 256,
+    :union_tag, 512,
+    :struct_tag, 1024,
+    :class_tag, 2048,
+    :namespace, 4096,
+    :nested_name_specifier, 8192,
+    :obj_c_interface, 16384,
+    :obj_c_protocol, 32768,
+    :obj_c_category, 65536,
+    :obj_c_instance_message, 131072,
+    :obj_c_class_message, 262144,
+    :obj_c_selector_name, 524288,
+    :macro_name, 1048576,
+    :natural_language, 2097152,
+    :unknown, 4194303
   ]
   
   # Returns a default set of code-completion options that can be
@@ -3511,18 +4868,15 @@ module FFIGen::Clang
   
   # Retrieve a diagnostic associated with the given code completion.
   # 
-  # Result: 
-  # the code completion results to query.
-  # 
   # @method code_complete_get_diagnostic(results, index)
-  # @param [CodeCompleteResults] results 
+  # @param [CodeCompleteResults] results the code completion results to query.
   # @param [Integer] index the zero-based diagnostic number to retrieve.
   # @return [FFI::Pointer(Diagnostic)] the requested diagnostic. This diagnostic must be freed
   #   via a call to \c clang_disposeDiagnostic().
   # @scope class
   attach_function :code_complete_get_diagnostic, :clang_codeCompleteGetDiagnostic, [CodeCompleteResults, :uint], :pointer
   
-  # Determines what compeltions are appropriate for the context
+  # Determines what completions are appropriate for the context
   # the given code completion.
   # 
   # @method code_complete_get_contexts(results)
@@ -3580,12 +4934,9 @@ module FFIGen::Clang
   
   # Enable/disable crash recovery.
   # 
-  # Flag: 
-  # to indicate if crash recovery is enabled.  A non-zero value
-  #        enables crash recovery, while 0 disables it.
-  # 
   # @method toggle_crash_recovery(is_enabled)
-  # @param [Integer] is_enabled 
+  # @param [Integer] is_enabled Flag to indicate if crash recovery is enabled.  A non-zero
+  #          value enables crash recovery, while 0 disables it.
   # @return [nil] 
   # @scope class
   attach_function :toggle_crash_recovery, :clang_toggleCrashRecovery, [:uint], :void
@@ -3594,7 +4945,7 @@ module FFIGen::Clang
   #        (used with clang_getInclusions()).
   # 
   # This visitor function will be invoked by clang_getInclusions() for each
-  # file included (either at the top-level or by #include directives) within
+  # file included (either at the top-level or by \#include directives) within
   # a translation unit.  The first argument is the file being included, and
   # the second and third arguments provide the inclusion stack.  The
   # array is sorted in order of immediate inclusion.  For example,
@@ -3632,6 +4983,16 @@ module FFIGen::Clang
   # @scope class
   attach_function :get_remappings, :clang_getRemappings, [:string], :pointer
   
+  # Retrieve a remapping.
+  # 
+  # @method get_remappings_from_file_list(file_paths, num_files)
+  # @param [FFI::Pointer(**CharS)] file_paths pointer to an array of file paths containing remapping info.
+  # @param [Integer] num_files number of file paths.
+  # @return [FFI::Pointer(Remapping)] the requested remapping. This remapping must be freed
+  #   via a call to \c clang_remap_dispose(). Can return NULL if an error occurred.
+  # @scope class
+  attach_function :get_remappings_from_file_list, :clang_getRemappingsFromFileList, [:pointer, :uint], :pointer
+  
   # Determine the number of remappings.
   # 
   # @method remap_get_num_files(remapping)
@@ -3667,22 +5028,20 @@ module FFIGen::Clang
   # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:visitor_result).</em>
   # 
   # === Options:
-  # :break ::
+  # :visit_break ::
   #   
-  # :continue ::
+  # :visit_continue ::
   #   
   # 
   # @method _enum_visitor_result_
   # @return [Symbol]
   # @scope class
   enum :visitor_result, [
-    :break,
-    :continue
+    :visit_break, 0,
+    :visit_continue, 1
   ]
   
-  # \defgroup CINDEX_HIGH Higher level API functions
-  # 
-  # @{
+  # (Not documented)
   # 
   # = Fields:
   # :context ::
@@ -3694,6 +5053,28 @@ module FFIGen::Clang
            :visit, :pointer
   end
   
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:result).</em>
+  # 
+  # === Options:
+  # :success ::
+  #   Function returned successfully.
+  # :invalid ::
+  #   One of the parameters was invalid for the function.
+  # :visit_break ::
+  #   The function was terminated by a callback (e.g. it returned
+  #   CXVisit_Break)
+  # 
+  # @method _enum_result_
+  # @return [Symbol]
+  # @scope class
+  enum :result, [
+    :success, 0,
+    :invalid, 1,
+    :visit_break, 2
+  ]
+  
   # Find references of a declaration in a specific file.
   # 
   # @method find_references_in_file(cursor, file, visitor)
@@ -3703,8 +5084,847 @@ module FFIGen::Clang
   #   each reference found.
   #   The CXSourceRange will point inside the file; if the reference is inside
   #   a macro (and not a macro argument) the CXSourceRange will be invalid.
+  # @return [Symbol from _enum_result_] one of the CXResult enumerators.
+  # @scope class
+  attach_function :find_references_in_file, :clang_findReferencesInFile, [Cursor.by_value, :pointer, CursorAndRangeVisitor.by_value], :result
+  
+  # Find #import/#include directives in a specific file.
+  # 
+  # @method find_includes_in_file(tu, file, visitor)
+  # @param [TranslationUnitImpl] tu translation unit containing the file to query.
+  # @param [FFI::Pointer(File)] file to search for #import/#include directives.
+  # @param [CursorAndRangeVisitor] visitor callback that will receive pairs of CXCursor/CXSourceRange for
+  #   each directive found.
+  # @return [Symbol from _enum_result_] one of the CXResult enumerators.
+  # @scope class
+  attach_function :find_includes_in_file, :clang_findIncludesInFile, [TranslationUnitImpl, :pointer, CursorAndRangeVisitor.by_value], :result
+  
+  # Source location passed to index callbacks.
+  # 
+  # = Fields:
+  # :ptr_data ::
+  #   (Array<FFI::Pointer(*Void)>) 
+  # :int_data ::
+  #   (Integer) 
+  class IdxLoc < FFI::Struct
+    layout :ptr_data, [:pointer, 2],
+           :int_data, :uint
+  end
+  
+  # Data for ppIncludedFile callback.
+  # 
+  # = Fields:
+  # :hash_loc ::
+  #   (IdxLoc) Location of '#' in the \#include/\#import directive.
+  # :filename ::
+  #   (String) Filename as written in the \#include/\#import directive.
+  # :file ::
+  #   (FFI::Pointer(File)) The actual file that the \#include/\#import directive resolved to.
+  # :is_import ::
+  #   (Integer) 
+  # :is_angled ::
+  #   (Integer) 
+  # :is_module_import ::
+  #   (Integer) Non-zero if the directive was automatically turned into a module
+  #   import.
+  class IdxIncludedFileInfo < FFI::Struct
+    layout :hash_loc, IdxLoc.by_value,
+           :filename, :string,
+           :file, :pointer,
+           :is_import, :int,
+           :is_angled, :int,
+           :is_module_import, :int
+  end
+  
+  # Data for IndexerCallbacks#importedASTFile.
+  # 
+  # = Fields:
+  # :file ::
+  #   (FFI::Pointer(File)) Top level AST file containing the imported PCH, module or submodule.
+  # :module_ ::
+  #   (FFI::Pointer(Module)) The imported module or NULL if the AST file is a PCH.
+  # :loc ::
+  #   (IdxLoc) Location where the file is imported. Applicable only for modules.
+  # :is_implicit ::
+  #   (Integer) Non-zero if an inclusion directive was automatically turned into
+  #   a module import. Applicable only for modules.
+  class IdxImportedASTFileInfo < FFI::Struct
+    layout :file, :pointer,
+           :module_, :pointer,
+           :loc, IdxLoc.by_value,
+           :is_implicit, :int
+  end
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_entity_kind).</em>
+  # 
+  # === Options:
+  # :unexposed ::
+  #   
+  # :typedef ::
+  #   
+  # :function ::
+  #   
+  # :variable ::
+  #   
+  # :field ::
+  #   
+  # :enum_constant ::
+  #   
+  # :obj_c_class ::
+  #   
+  # :obj_c_protocol ::
+  #   
+  # :obj_c_category ::
+  #   
+  # :obj_c_instance_method ::
+  #   
+  # :obj_c_class_method ::
+  #   
+  # :obj_c_property ::
+  #   
+  # :obj_c_ivar ::
+  #   
+  # :enum ::
+  #   
+  # :struct ::
+  #   
+  # :union ::
+  #   
+  # :cxx_class ::
+  #   
+  # :cxx_namespace ::
+  #   
+  # :cxx_namespace_alias ::
+  #   
+  # :cxx_static_variable ::
+  #   
+  # :cxx_static_method ::
+  #   
+  # :cxx_instance_method ::
+  #   
+  # :cxx_constructor ::
+  #   
+  # :cxx_destructor ::
+  #   
+  # :cxx_conversion_function ::
+  #   
+  # :cxx_type_alias ::
+  #   
+  # :cxx_interface ::
+  #   
+  # 
+  # @method _enum_idx_entity_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_entity_kind, [
+    :unexposed, 0,
+    :typedef, 1,
+    :function, 2,
+    :variable, 3,
+    :field, 4,
+    :enum_constant, 5,
+    :obj_c_class, 6,
+    :obj_c_protocol, 7,
+    :obj_c_category, 8,
+    :obj_c_instance_method, 9,
+    :obj_c_class_method, 10,
+    :obj_c_property, 11,
+    :obj_c_ivar, 12,
+    :enum, 13,
+    :struct, 14,
+    :union, 15,
+    :cxx_class, 16,
+    :cxx_namespace, 17,
+    :cxx_namespace_alias, 18,
+    :cxx_static_variable, 19,
+    :cxx_static_method, 20,
+    :cxx_instance_method, 21,
+    :cxx_constructor, 22,
+    :cxx_destructor, 23,
+    :cxx_conversion_function, 24,
+    :cxx_type_alias, 25,
+    :cxx_interface, 26
+  ]
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_entity_language).</em>
+  # 
+  # === Options:
+  # :lang_none ::
+  #   
+  # :lang_c ::
+  #   
+  # :lang_obj_c ::
+  #   
+  # :lang_cxx ::
+  #   
+  # 
+  # @method _enum_idx_entity_language_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_entity_language, [
+    :lang_none, 0,
+    :lang_c, 1,
+    :lang_obj_c, 2,
+    :lang_cxx, 3
+  ]
+  
+  # Extra C++ template information for an entity. This can apply to:
+  # CXIdxEntity_Function
+  # CXIdxEntity_CXXClass
+  # CXIdxEntity_CXXStaticMethod
+  # CXIdxEntity_CXXInstanceMethod
+  # CXIdxEntity_CXXConstructor
+  # CXIdxEntity_CXXConversionFunction
+  # CXIdxEntity_CXXTypeAlias
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_entity_cxx_template_kind).</em>
+  # 
+  # === Options:
+  # :non_template ::
+  #   
+  # :template ::
+  #   
+  # :template_partial_specialization ::
+  #   
+  # :template_specialization ::
+  #   
+  # 
+  # @method _enum_idx_entity_cxx_template_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_entity_cxx_template_kind, [
+    :non_template, 0,
+    :template, 1,
+    :template_partial_specialization, 2,
+    :template_specialization, 3
+  ]
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_attr_kind).</em>
+  # 
+  # === Options:
+  # :unexposed ::
+  #   
+  # :ib_action ::
+  #   
+  # :ib_outlet ::
+  #   
+  # :ib_outlet_collection ::
+  #   
+  # 
+  # @method _enum_idx_attr_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_attr_kind, [
+    :unexposed, 0,
+    :ib_action, 1,
+    :ib_outlet, 2,
+    :ib_outlet_collection, 3
+  ]
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :kind ::
+  #   (Symbol from _enum_idx_attr_kind_) 
+  # :cursor ::
+  #   (Cursor) 
+  # :loc ::
+  #   (IdxLoc) 
+  class IdxAttrInfo < FFI::Struct
+    layout :kind, :idx_attr_kind,
+           :cursor, Cursor.by_value,
+           :loc, IdxLoc.by_value
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :kind ::
+  #   (Symbol from _enum_idx_entity_kind_) 
+  # :template_kind ::
+  #   (Symbol from _enum_idx_entity_cxx_template_kind_) 
+  # :lang ::
+  #   (Symbol from _enum_idx_entity_language_) 
+  # :name ::
+  #   (String) 
+  # :usr ::
+  #   (String) 
+  # :cursor ::
+  #   (Cursor) 
+  # :attributes ::
+  #   (FFI::Pointer(**IdxAttrInfo)) 
+  # :num_attributes ::
+  #   (Integer) 
+  class IdxEntityInfo < FFI::Struct
+    layout :kind, :idx_entity_kind,
+           :template_kind, :idx_entity_cxx_template_kind,
+           :lang, :idx_entity_language,
+           :name, :string,
+           :usr, :string,
+           :cursor, Cursor.by_value,
+           :attributes, :pointer,
+           :num_attributes, :uint
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :cursor ::
+  #   (Cursor) 
+  class IdxContainerInfo < FFI::Struct
+    layout :cursor, Cursor.by_value
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :attr_info ::
+  #   (IdxAttrInfo) 
+  # :objc_class ::
+  #   (IdxEntityInfo) 
+  # :class_cursor ::
+  #   (Cursor) 
+  # :class_loc ::
+  #   (IdxLoc) 
+  class IdxIBOutletCollectionAttrInfo < FFI::Struct
+    layout :attr_info, IdxAttrInfo,
+           :objc_class, IdxEntityInfo,
+           :class_cursor, Cursor.by_value,
+           :class_loc, IdxLoc.by_value
+  end
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_decl_info_flags).</em>
+  # 
+  # === Options:
+  # :idx_decl_flag_skipped ::
+  #   
+  # 
+  # @method _enum_idx_decl_info_flags_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_decl_info_flags, [
+    :idx_decl_flag_skipped, 1
+  ]
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :entity_info ::
+  #   (IdxEntityInfo) 
+  # :cursor ::
+  #   (Cursor) 
+  # :loc ::
+  #   (IdxLoc) 
+  # :semantic_container ::
+  #   (IdxContainerInfo) 
+  # :lexical_container ::
+  #   (IdxContainerInfo) Generally same as #semanticContainer but can be different in
+  #   cases like out-of-line C++ member functions.
+  # :is_redeclaration ::
+  #   (Integer) 
+  # :is_definition ::
+  #   (Integer) 
+  # :is_container ::
+  #   (Integer) 
+  # :decl_as_container ::
+  #   (IdxContainerInfo) 
+  # :is_implicit ::
+  #   (Integer) Whether the declaration exists in code or was created implicitly
+  #   by the compiler, e.g. implicit Objective-C methods for properties.
+  # :attributes ::
+  #   (FFI::Pointer(**IdxAttrInfo)) 
+  # :num_attributes ::
+  #   (Integer) 
+  # :flags ::
+  #   (Integer) 
+  class IdxDeclInfo < FFI::Struct
+    layout :entity_info, IdxEntityInfo,
+           :cursor, Cursor.by_value,
+           :loc, IdxLoc.by_value,
+           :semantic_container, IdxContainerInfo,
+           :lexical_container, IdxContainerInfo,
+           :is_redeclaration, :int,
+           :is_definition, :int,
+           :is_container, :int,
+           :decl_as_container, IdxContainerInfo,
+           :is_implicit, :int,
+           :attributes, :pointer,
+           :num_attributes, :uint,
+           :flags, :uint
+  end
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_obj_c_container_kind).</em>
+  # 
+  # === Options:
+  # :forward_ref ::
+  #   
+  # :interface ::
+  #   
+  # :implementation ::
+  #   
+  # 
+  # @method _enum_idx_obj_c_container_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_obj_c_container_kind, [
+    :forward_ref, 0,
+    :interface, 1,
+    :implementation, 2
+  ]
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :decl_info ::
+  #   (IdxDeclInfo) 
+  # :kind ::
+  #   (Symbol from _enum_idx_obj_c_container_kind_) 
+  class IdxObjCContainerDeclInfo < FFI::Struct
+    layout :decl_info, IdxDeclInfo,
+           :kind, :idx_obj_c_container_kind
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :base ::
+  #   (IdxEntityInfo) 
+  # :cursor ::
+  #   (Cursor) 
+  # :loc ::
+  #   (IdxLoc) 
+  class IdxBaseClassInfo < FFI::Struct
+    layout :base, IdxEntityInfo,
+           :cursor, Cursor.by_value,
+           :loc, IdxLoc.by_value
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :protocol ::
+  #   (IdxEntityInfo) 
+  # :cursor ::
+  #   (Cursor) 
+  # :loc ::
+  #   (IdxLoc) 
+  class IdxObjCProtocolRefInfo < FFI::Struct
+    layout :protocol, IdxEntityInfo,
+           :cursor, Cursor.by_value,
+           :loc, IdxLoc.by_value
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :protocols ::
+  #   (FFI::Pointer(**IdxObjCProtocolRefInfo)) 
+  # :num_protocols ::
+  #   (Integer) 
+  class IdxObjCProtocolRefListInfo < FFI::Struct
+    layout :protocols, :pointer,
+           :num_protocols, :uint
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :container_info ::
+  #   (IdxObjCContainerDeclInfo) 
+  # :super_info ::
+  #   (IdxBaseClassInfo) 
+  # :protocols ::
+  #   (IdxObjCProtocolRefListInfo) 
+  class IdxObjCInterfaceDeclInfo < FFI::Struct
+    layout :container_info, IdxObjCContainerDeclInfo,
+           :super_info, IdxBaseClassInfo,
+           :protocols, IdxObjCProtocolRefListInfo
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :container_info ::
+  #   (IdxObjCContainerDeclInfo) 
+  # :objc_class ::
+  #   (IdxEntityInfo) 
+  # :class_cursor ::
+  #   (Cursor) 
+  # :class_loc ::
+  #   (IdxLoc) 
+  # :protocols ::
+  #   (IdxObjCProtocolRefListInfo) 
+  class IdxObjCCategoryDeclInfo < FFI::Struct
+    layout :container_info, IdxObjCContainerDeclInfo,
+           :objc_class, IdxEntityInfo,
+           :class_cursor, Cursor.by_value,
+           :class_loc, IdxLoc.by_value,
+           :protocols, IdxObjCProtocolRefListInfo
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :decl_info ::
+  #   (IdxDeclInfo) 
+  # :getter ::
+  #   (IdxEntityInfo) 
+  # :setter ::
+  #   (IdxEntityInfo) 
+  class IdxObjCPropertyDeclInfo < FFI::Struct
+    layout :decl_info, IdxDeclInfo,
+           :getter, IdxEntityInfo,
+           :setter, IdxEntityInfo
+  end
+  
+  # (Not documented)
+  # 
+  # = Fields:
+  # :decl_info ::
+  #   (IdxDeclInfo) 
+  # :bases ::
+  #   (FFI::Pointer(**IdxBaseClassInfo)) 
+  # :num_bases ::
+  #   (Integer) 
+  class IdxCXXClassDeclInfo < FFI::Struct
+    layout :decl_info, IdxDeclInfo,
+           :bases, :pointer,
+           :num_bases, :uint
+  end
+  
+  # Data for IndexerCallbacks#indexEntityReference.
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:idx_entity_ref_kind).</em>
+  # 
+  # === Options:
+  # :direct ::
+  #   The entity is referenced directly in user's code.
+  # :implicit ::
+  #   An implicit reference, e.g. a reference of an Objective-C method
+  #   via the dot syntax.
+  # 
+  # @method _enum_idx_entity_ref_kind_
+  # @return [Symbol]
+  # @scope class
+  enum :idx_entity_ref_kind, [
+    :direct, 1,
+    :implicit, 2
+  ]
+  
+  # Data for IndexerCallbacks#indexEntityReference.
+  # 
+  # = Fields:
+  # :kind ::
+  #   (Symbol from _enum_idx_entity_ref_kind_) 
+  # :cursor ::
+  #   (Cursor) Reference cursor.
+  # :loc ::
+  #   (IdxLoc) 
+  # :referenced_entity ::
+  #   (IdxEntityInfo) The entity that gets referenced.
+  # :parent_entity ::
+  #   (IdxEntityInfo) Immediate "parent" of the reference. For example:
+  #   
+  #   \code
+  #   Foo *var;
+  #   \endcode
+  #   
+  #   The parent of reference of type 'Foo' is the variable 'var'.
+  #   For references inside statement bodies of functions/methods,
+  #   the parentEntity will be the function/method.
+  # :container ::
+  #   (IdxContainerInfo) Lexical container context of the reference.
+  class IdxEntityRefInfo < FFI::Struct
+    layout :kind, :idx_entity_ref_kind,
+           :cursor, Cursor.by_value,
+           :loc, IdxLoc.by_value,
+           :referenced_entity, IdxEntityInfo,
+           :parent_entity, IdxEntityInfo,
+           :container, IdxContainerInfo
+  end
+  
+  # A group of callbacks used by #clang_indexSourceFile and
+  # #clang_indexTranslationUnit.
+  # 
+  # = Fields:
+  # :abort_query ::
+  #   (FFI::Pointer(*)) Called periodically to check whether indexing should be aborted.
+  #   Should return 0 to continue, and non-zero to abort.
+  # :diagnostic ::
+  #   (FFI::Pointer(*)) Called at the end of indexing; passes the complete diagnostic set.
+  # :entered_main_file ::
+  #   (FFI::Pointer(*)) 
+  # :pp_included_file ::
+  #   (FFI::Pointer(*)) Called when a file gets \#included/\#imported.
+  # :imported_ast_file ::
+  #   (FFI::Pointer(*)) Called when a AST file (PCH or module) gets imported.
+  #   
+  #   AST files will not get indexed (there will not be callbacks to index all
+  #   the entities in an AST file). The recommended action is that, if the AST
+  #   file is not already indexed, to initiate a new indexing job specific to
+  #   the AST file.
+  # :started_translation_unit ::
+  #   (FFI::Pointer(*)) Called at the beginning of indexing a translation unit.
+  # :index_declaration ::
+  #   (FFI::Pointer(*)) 
+  # :index_entity_reference ::
+  #   (FFI::Pointer(*)) Called to index a reference of an entity.
+  class IndexerCallbacks < FFI::Struct
+    layout :abort_query, :pointer,
+           :diagnostic, :pointer,
+           :entered_main_file, :pointer,
+           :pp_included_file, :pointer,
+           :imported_ast_file, :pointer,
+           :started_translation_unit, :pointer,
+           :index_declaration, :pointer,
+           :index_entity_reference, :pointer
+  end
+  
+  # (Not documented)
+  # 
+  # @method index_is_entity_obj_c_container_kind(idx_entity_kind)
+  # @param [Symbol from _enum_idx_entity_kind_] idx_entity_kind 
+  # @return [Integer] 
+  # @scope class
+  attach_function :index_is_entity_obj_c_container_kind, :clang_index_isEntityObjCContainerKind, [:idx_entity_kind], :int
+  
+  # (Not documented)
+  # 
+  # @method index_get_obj_c_container_decl_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxObjCContainerDeclInfo] 
+  # @scope class
+  attach_function :index_get_obj_c_container_decl_info, :clang_index_getObjCContainerDeclInfo, [IdxDeclInfo], IdxObjCContainerDeclInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_obj_c_interface_decl_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxObjCInterfaceDeclInfo] 
+  # @scope class
+  attach_function :index_get_obj_c_interface_decl_info, :clang_index_getObjCInterfaceDeclInfo, [IdxDeclInfo], IdxObjCInterfaceDeclInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_obj_c_category_decl_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxObjCCategoryDeclInfo] 
+  # @scope class
+  attach_function :index_get_obj_c_category_decl_info, :clang_index_getObjCCategoryDeclInfo, [IdxDeclInfo], IdxObjCCategoryDeclInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_obj_c_protocol_ref_list_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxObjCProtocolRefListInfo] 
+  # @scope class
+  attach_function :index_get_obj_c_protocol_ref_list_info, :clang_index_getObjCProtocolRefListInfo, [IdxDeclInfo], IdxObjCProtocolRefListInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_obj_c_property_decl_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxObjCPropertyDeclInfo] 
+  # @scope class
+  attach_function :index_get_obj_c_property_decl_info, :clang_index_getObjCPropertyDeclInfo, [IdxDeclInfo], IdxObjCPropertyDeclInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_ib_outlet_collection_attr_info(idx_attr_info)
+  # @param [IdxAttrInfo] idx_attr_info 
+  # @return [IdxIBOutletCollectionAttrInfo] 
+  # @scope class
+  attach_function :index_get_ib_outlet_collection_attr_info, :clang_index_getIBOutletCollectionAttrInfo, [IdxAttrInfo], IdxIBOutletCollectionAttrInfo
+  
+  # (Not documented)
+  # 
+  # @method index_get_cxx_class_decl_info(idx_decl_info)
+  # @param [IdxDeclInfo] idx_decl_info 
+  # @return [IdxCXXClassDeclInfo] 
+  # @scope class
+  attach_function :index_get_cxx_class_decl_info, :clang_index_getCXXClassDeclInfo, [IdxDeclInfo], IdxCXXClassDeclInfo
+  
+  # For retrieving a custom CXIdxClientContainer attached to a
+  # container.
+  # 
+  # @method index_get_client_container(idx_container_info)
+  # @param [IdxContainerInfo] idx_container_info 
+  # @return [FFI::Pointer(IdxClientContainer)] 
+  # @scope class
+  attach_function :index_get_client_container, :clang_index_getClientContainer, [IdxContainerInfo], :pointer
+  
+  # For setting a custom CXIdxClientContainer attached to a
+  # container.
+  # 
+  # @method index_set_client_container(idx_container_info, idx_client_container)
+  # @param [IdxContainerInfo] idx_container_info 
+  # @param [FFI::Pointer(IdxClientContainer)] idx_client_container 
   # @return [nil] 
   # @scope class
-  attach_function :find_references_in_file, :clang_findReferencesInFile, [Cursor.by_value, :pointer, CursorAndRangeVisitor.by_value], :void
+  attach_function :index_set_client_container, :clang_index_setClientContainer, [IdxContainerInfo, :pointer], :void
+  
+  # For retrieving a custom CXIdxClientEntity attached to an entity.
+  # 
+  # @method index_get_client_entity(idx_entity_info)
+  # @param [IdxEntityInfo] idx_entity_info 
+  # @return [FFI::Pointer(IdxClientEntity)] 
+  # @scope class
+  attach_function :index_get_client_entity, :clang_index_getClientEntity, [IdxEntityInfo], :pointer
+  
+  # For setting a custom CXIdxClientEntity attached to an entity.
+  # 
+  # @method index_set_client_entity(idx_entity_info, idx_client_entity)
+  # @param [IdxEntityInfo] idx_entity_info 
+  # @param [FFI::Pointer(IdxClientEntity)] idx_client_entity 
+  # @return [nil] 
+  # @scope class
+  attach_function :index_set_client_entity, :clang_index_setClientEntity, [IdxEntityInfo, :pointer], :void
+  
+  # An indexing action/session, to be applied to one or multiple
+  # translation units.
+  # 
+  # @method index_action_create(c_idx)
+  # @param [FFI::Pointer(Index)] c_idx The index object with which the index action will be associated.
+  # @return [FFI::Pointer(IndexAction)] 
+  # @scope class
+  attach_function :index_action_create, :clang_IndexAction_create, [:pointer], :pointer
+  
+  # Destroy the given index action.
+  # 
+  # The index action must not be destroyed until all of the translation units
+  # created within that index action have been destroyed.
+  # 
+  # @method index_action_dispose(index_action)
+  # @param [FFI::Pointer(IndexAction)] index_action 
+  # @return [nil] 
+  # @scope class
+  attach_function :index_action_dispose, :clang_IndexAction_dispose, [:pointer], :void
+  
+  # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:index_opt_flags).</em>
+  # 
+  # === Options:
+  # :none ::
+  #   Used to indicate that no special indexing options are needed.
+  # :suppress_redundant_refs ::
+  #   Used to indicate that IndexerCallbacks#indexEntityReference should
+  #   be invoked for only one reference of an entity per source file that does
+  #   not also include a declaration/definition of the entity.
+  # :index_function_local_symbols ::
+  #   Function-local symbols should be indexed. If this is not set
+  #   function-local symbols will be ignored.
+  # :index_implicit_template_instantiations ::
+  #   Implicit function/class template instantiations should be indexed.
+  #   If this is not set, implicit instantiations will be ignored.
+  # :suppress_warnings ::
+  #   Suppress all compiler warnings when parsing for indexing.
+  # :skip_parsed_bodies_in_session ::
+  #   Skip a function/method body that was already parsed during an
+  #   indexing session associated with a \c CXIndexAction object.
+  #   Bodies in system headers are always skipped.
+  # 
+  # @method _enum_index_opt_flags_
+  # @return [Symbol]
+  # @scope class
+  enum :index_opt_flags, [
+    :none, 0,
+    :suppress_redundant_refs, 1,
+    :index_function_local_symbols, 2,
+    :index_implicit_template_instantiations, 4,
+    :suppress_warnings, 8,
+    :skip_parsed_bodies_in_session, 16
+  ]
+  
+  # Index the given source file and the translation unit corresponding
+  # to that file via callbacks implemented through #IndexerCallbacks.
+  # 
+  # @method index_source_file(index_action, client_data, index_callbacks, index_callbacks_size, index_options, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, out_tu, tu_options)
+  # @param [FFI::Pointer(IndexAction)] index_action 
+  # @param [FFI::Pointer(ClientData)] client_data pointer data supplied by the client, which will
+  #   be passed to the invoked callbacks.
+  # @param [IndexerCallbacks] index_callbacks Pointer to indexing callbacks that the client
+  #   implements.
+  # @param [Integer] index_callbacks_size Size of #IndexerCallbacks structure that gets
+  #   passed in index_callbacks.
+  # @param [Integer] index_options A bitmask of options that affects how indexing is
+  #   performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
+  #   
+  #   \param(out) out_TU pointer to store a \c CXTranslationUnit that can be
+  #   reused after indexing is finished. Set to \c NULL if you do not require it.
+  # @param [String] source_filename 
+  # @param [FFI::Pointer(**CharS)] command_line_args 
+  # @param [Integer] num_command_line_args 
+  # @param [UnsavedFile] unsaved_files 
+  # @param [Integer] num_unsaved_files 
+  # @param [FFI::Pointer(*TranslationUnit)] out_tu 
+  # @param [Integer] tu_options 
+  # @return [Integer] 0 on success or if there were errors from which the compiler could
+  #   recover.  If there is a failure from which the there is no recovery, returns
+  #   a non-zero \c CXErrorCode.
+  #   
+  #   The rest of the parameters are the same as #clang_parseTranslationUnit.
+  # @scope class
+  attach_function :index_source_file, :clang_indexSourceFile, [:pointer, :pointer, IndexerCallbacks, :uint, :uint, :string, :pointer, :int, UnsavedFile, :uint, :pointer, :uint], :int
+  
+  # Index the given translation unit via callbacks implemented through
+  # #IndexerCallbacks.
+  # 
+  # The order of callback invocations is not guaranteed to be the same as
+  # when indexing a source file. The high level order will be:
+  # 
+  #   -Preprocessor callbacks invocations
+  #   -Declaration/reference callbacks invocations
+  #   -Diagnostic callback invocations
+  # 
+  # The parameters are the same as #clang_indexSourceFile.
+  # 
+  # @method index_translation_unit(index_action, client_data, index_callbacks, index_callbacks_size, index_options, translation_unit_impl)
+  # @param [FFI::Pointer(IndexAction)] index_action 
+  # @param [FFI::Pointer(ClientData)] client_data 
+  # @param [IndexerCallbacks] index_callbacks 
+  # @param [Integer] index_callbacks_size 
+  # @param [Integer] index_options 
+  # @param [TranslationUnitImpl] translation_unit_impl 
+  # @return [Integer] If there is a failure from which the there is no recovery, returns
+  #   non-zero, otherwise returns 0.
+  # @scope class
+  attach_function :index_translation_unit, :clang_indexTranslationUnit, [:pointer, :pointer, IndexerCallbacks, :uint, :uint, TranslationUnitImpl], :int
+  
+  # Retrieve the CXIdxFile, file, line, column, and offset represented by
+  # the given CXIdxLoc.
+  # 
+  # If the location refers into a macro expansion, retrieves the
+  # location of the macro expansion and if it refers into a macro argument
+  # retrieves the location of the argument.
+  # 
+  # @method index_loc_get_file_location(loc, index_file, file, line, column, offset)
+  # @param [IdxLoc] loc 
+  # @param [FFI::Pointer(*IdxClientFile)] index_file 
+  # @param [FFI::Pointer(*File)] file 
+  # @param [FFI::Pointer(*UInt)] line 
+  # @param [FFI::Pointer(*UInt)] column 
+  # @param [FFI::Pointer(*UInt)] offset 
+  # @return [nil] 
+  # @scope class
+  attach_function :index_loc_get_file_location, :clang_indexLoc_getFileLocation, [IdxLoc.by_value, :pointer, :pointer, :pointer, :pointer, :pointer], :void
+  
+  # Retrieve the CXSourceLocation represented by the given CXIdxLoc.
+  # 
+  # @method index_loc_get_cx_source_location(loc)
+  # @param [IdxLoc] loc 
+  # @return [SourceLocation] 
+  # @scope class
+  attach_function :index_loc_get_cx_source_location, :clang_indexLoc_getCXSourceLocation, [IdxLoc.by_value], SourceLocation.by_value
   
 end

--- a/lib/ffi_gen/ruby_output.rb
+++ b/lib/ffi_gen/ruby_output.rb
@@ -5,7 +5,7 @@ class FFIGen
     writer.indent do
       writer.puts "extend FFI::Library"
       writer.puts "ffi_lib_flags #{@ffi_lib_flags.map(&:inspect).join(', ')}" if @ffi_lib_flags
-      writer.puts "ffi_lib '#{@ffi_lib}'", "" if @ffi_lib
+      writer.puts "ffi_lib #{@ffi_lib.inspect}", "" if @ffi_lib
       writer.puts "def self.attach_function(name, *_)", "  begin; super; rescue FFI::NotFoundError => e", "    (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }", "  end", "end", ""
       declarations.each do |declaration|
         declaration.write_ruby writer


### PR DESCRIPTION
This PR contains a few updates that I had to do to be able to conveniently use ffi_gen on Debian with LLVM.

Specifically:
  * upgrade to libclang 3.5 allows to fix https://github.com/neelance/ffi_gen/issues/29;
  * allowing to specify a list of library names in ffi_lib allows to accomodate for Debian, which doesn't have a `libclang.so` (only `libclang.so.1` and `libclang-3.5.so.1`); binding to a more specific libclang version first allows to avoid issues where e.g. a function returns a enum value unknown in a previous version;
  * gemspec was updated to avoid warnings from gem build.